### PR TITLE
Number questions in poster FAQ

### DIFF
--- a/year/2017/info/call-participation/posters-faq.md
+++ b/year/2017/info/call-participation/posters-faq.md
@@ -4,42 +4,42 @@ layout: main-2017
 permalink: /year/2017/info/call-participation/posters-faq
 ---
 
-*What is the purpose of submitting a poster?*
+*1. What is the purpose of submitting a poster?*
 
 There are different reasons for submitting work as a poster. Maybe the work wasn't quite mature enough at the papers deadline, but you would like to show it to your colleagues. You want some feedback on what others think about work that is at an early stage. Maybe the findings are interesting, but the contribution does not warrant a full paper - student projects often fall into this category. Perhaps you have developed or applied ideas presented in a previous paper or submission, or applied existing ideas in a new context. You may have some late breaking results or a new application you want to show the world before writing a complete paper. Or your work may be best suited to the poster format where the emphasis is on graphics and discussion. A poster presentation provides you with the chance to get more feedback than with a paper presentation, and you can get in contact with people working in a similar field, or who are interested in your work.
 
-*Will posters be published/indexed through IEEE Xplore?*
+*2. Will posters be published/indexed through IEEE Xplore?*
 
 No, posters will **not** be published/indexed through IEEE Xplore. The aim of the VIS posters session is to highlight new work and work in progress. To ensure that authors can publish their finished work at conferences or in journals, poster summaries that are part of the IEEE VIS poster program are not considered to be peer-reviewed publications. This approach allows authors to fully re-use their material for publication of their finished work and avoids copyright issues with IEEE.
 
-*What are my responsibilities as a poster author?*
+*3. What are my responsibilities as a poster author?*
 
 To facilitate dissemination, discussion, and access, posters will be on display during the whole of IEEE VIS. Authors will be expected to set up their posters on the first morning of the conference, and take them down on the penultimate evening. Posters are also presented in person, first at the fast-paced poster summary session, and then by standing with the poster during the poster session itself to describe the work and to answer questions. If the poster has multiple authors, not all authors need to be there, however the poster must be staffed by at least one person at all times during the poster session. Multiple authors may wish to "tag team," taking turns at their own poster and then seeing the other poster presentations.
 
-*What do I have to submit: the two-page summary, the poster, or both?*
+*4. What do I have to submit: the two-page summary, the poster, or both?*
 
 You need to submit the two-page summary and any accompanying materials that help explain your work and that are indicative of what you will show at the poster session. We encourage you to also submit a draft layout, even if this is only a sketch, as it helps reviewers see how you are addressing the criteria. The poster itself only needs to be prepared for accepted submissions and brought to the actual poster session at the conference.
 
-*Can I get an extension to the deadline?*
+*5. Can I get an extension to the deadline?*
 
 The submission deadline is a hard deadline. We do not give extensions because we are on a tight schedule and because it would be unfair to other participants who meet the deadline.
 
-*What makes for a good poster?*
+*6. What makes for a good poster?*
 
 The key content of the poster should be easy to interpret from two or three meters away. The poster may also have more dense text or graphics, suitable for viewers who come for a closer look, standing perhaps one meter away. Consider also that the material on the poster should be useful for you to illustrate important aspects of your work when discussing it individually with attendees during your session. This may involve text, but may focus predominantly on graphics - it is IEEE VIS after all! Don't forget to include your name, affiliation, and contact information on the poster. At the poster session, you should have your business card or a leaflet ready to give to interested people.
 
-*What is the expected physical format of a poster?*
+*7. What is the expected physical format of a poster?*
 
 Posters are usually printed with a large-format printer onto a large piece of paper (A0 maximum, 841mm x 1189mm / 33.1" x 46.8"), which covers most or all of the poster board it is mounted on. A less attractive option is to form the poster from a collection of individual letter-size sheets of paper, either as the individual pages of the presentation, or as "tiles" of a single large-format document. It's really up to you how you fill the A0 space. At the conference, you will mount your poster onto a poster board for display. Each poster will be allocated a poster board and a map of poster locations will help delegates find you. Poster boards and push-pins will be supplied by the conference organizers.
 
-*Will I have an internet connection for my laptop?*
+*8. Will I have an internet connection for my laptop?*
 
 No - we can't guarantee this. You shouldn't plan on having an internet connection during your session as we cannot guarantee that there will be reliable wireless access.
 
-*Will AC power be available for my laptop or other devices?*
+*9. Will AC power be available for my laptop or other devices?*
 
 Sorry, we can't promise AC power outlets. Please charge your batteries before the session.
 
-*Can I leave my laptop or other equipment in the poster area before or after the session?*
+*10. Can I leave my laptop or other equipment in the poster area before or after the session?*
 
 The poster session is in an unsecured open area. Keep an eye on your laptop and take all your gear with you.


### PR DESCRIPTION
(Manually) numbered the questions in the poster FAQ to make the headings to stand out more. (I couldn't find an automatic way to generate numbered headings in markdown. If there is a better way to accomplish this goal, please let me know.)