### PR TITLE
Update left_sidebar-2017.html

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -43,10 +43,10 @@
        <!-- <li><a href="http://biovis.net/2016/">BioVis Challenge 2017</a></li>
 	    <li><a href="http://vacommunity.org/VAST+Challenge+2016">VAST Challenge 2017</a></li>
             <li><a href="http://www.ldav.org/">IEEE LDAV 2017</a></li> -->
+	    <li><a href="https://www.dkrz.de/SciVis/">SciVis Contest</a></li>
             <li><a href="http://www.visualanalyticshealthcare.org/">VAHC 2017</a></li>
 	    <li><a href="http://www.visualdatascience.org/2017/index.html">VDS 2017</a></li>
        <!-- <li><a href="http://vizsec.org/">IEEE VizSec 2017</a></li>
-            <li><a href="http://www.uni-kl.de/sciviscontest/">SciVis Contest 2017</a></li>
 	    <li><a href="http://visap.uic.edu/2016/">IEEE VIS Arts Program 2017</a></li>
 	    <li><a href="http://www.gicentre.net/velo-club-de-vis">Velo Club de VIS</a></li>
 	    <li><a href="http://vacommunity.org/ieeevpg/reception/">IEEE VPG Reception</a></li> -->
@@ -71,12 +71,6 @@
 	      <a href="/year/2017/info/committees/infovis-steering-committee">InfoVis</a> &#183;
 	      <a href="/year/2017/info/committees/scivis-steering-committee">SciVis</a>
 	    </li>
-	  </ol>
-	</div>
-	<p></p>
-	<div><h3 class="menu-title">Associated Events</h3>
-	  <ol class="link-leftbar">
-	    <li><a href="https://www.dkrz.de/SciVis/">SciVis Contest</a></li>
 	  </ol>
 	</div>
 	<p></p>


### PR DESCRIPTION
'Associated Events' appeared twice in main menu - I merged them together. 'Associated Events' should appear above 'Supporters and Exhibition'.