### PR TITLE
Adding VizSec link.

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -43,7 +43,7 @@
             <li>BioVis Challenge</li>
 	    <li>VAST Challenge</li>
             <li>IEEE LDAV</li>
-            <li>IEEE VizSec</li>
+            <li><a href="http://vizsec.org/">VizSec</a></li>
             <li>IEEE VIS Arts Program 2017</li>
 	    <li>Velo Club de VIS</li>
 	    <li>IEEE VPG Reception</li>


### PR DESCRIPTION
Adding VizSec link and removing "IEEE" from the name. (Not sure what the sort order is for the events, but kept VizSec in the same place as before.)