### PR TITLE
Add LDAV link in sidebar.

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -42,7 +42,7 @@
 	    <li><a href="https://www.dkrz.de/SciVis/">SciVis Contest</a></li>
             <li>BioVis Challenge</li>
 	    <li>VAST Challenge</li>
-            <li>IEEE LDAV</li>
+            <li><a href="http://ldav.org/">LDAV</a></li>
             <li>IEEE VizSec</li>
             <li>IEEE VIS Arts Program 2017</li>
 	    <li>Velo Club de VIS</li>


### PR DESCRIPTION
Add LDAV link in sidebar. Remove "IEEE" prefix – while it's the "IEEE Symposium on ...", it has never been called "IEEE LDAV".