### PR TITLE
Update left_sidebar-2017.html

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -37,16 +37,16 @@
 	</div>
 	      <div><h3 class="menu-title">Associated Events</h3>
 	  <ol class="link-leftbar">
-            <li><a href="http://www.visualanalyticshealthcare.org/">VAHC 2017</a></li>
-	    <li><a href="http://www.visualdatascience.org/2017/index.html">VDS 2017</a></li>
-	    <li><a href="https://www.dkrz.de/SciVis/">SciVis Contest</a></li>
-            <li>BioVis Challenge</li>
+            <li><a href="http://www.visualanalyticshealthcare.org/">Visual Analytics in Healthcare</a></li>
+	    <li><a href="http://www.visualdatascience.org/2017/index.html">Visualization in Data Science</a></li>
+	    <li><a href="http://sciviscontest-staging.ieeevis.org/">SciVis Contest</a></li>
+            <li><a href="http://biovis.net/2017/ieeevis/">BioVis Challenge</a></li>
 	    <li>VAST Challenge</li>
-            <li><a href="http://ldav.org/">LDAV</a></li>
+            <li><a href="http://ldav.org/">Large Data Analysis and Visualization</a></li>
             <li><a href="http://vizsec.org/">VizSec</a></li>
-            <li>IEEE VIS Arts Program 2017</li>
+	    <li><a href="http://visap.uic.edu/2017/callforentries.html">VIS Arts Program</a></li>
 	    <li>Velo Club de VIS</li>
-	    <li>IEEE VPG Reception</li>
+	    <li>Vis Pioneers Group</li>
 	  </ol>
 	</div>
 	<div id="supporters-leftbar">


### PR DESCRIPTION
1) SciVis Contest - request that link be changed to: http://sciviscontest-staging.ieeevis.org/
2) Remove all IEEE in Associated Events, e.g., LDAV, VizSec, Arts, VPG should not have IEEE
3) VAHC is replaced with Visual Analytics in Healthcare
4) VDS is replaced with Visualization in Data Science
5) LDAV is replaced with Large Data Analysis and Visualization
6) VPG Reception is replaced with Vis Pioneers Group
7) Vis Arts Program link now to: http://visap.uic.edu/2017/callforentries.html 
8) LDAV link should now link to http://www.ldav.org/
9) VizSec should link to http://vizsec.org/
10) Biovis link to http://biovis.net/2017/ieeevis/