### PR TITLE
Initial drop for VIP CfP

### DIFF
--- a/year/2017/info/call-participation/vip.md
+++ b/year/2017/info/call-participation/vip.md
@@ -1,0 +1,53 @@
+---
+title: Vis in Practice
+layout: main-2017
+permalink: /year/2017/info/call-participation/vip
+contact: vip@ieeevis.org
+---
+
+## 2017 Workshop on Visualization in Practice
+# Visualization Solutions in the Wild
+## Call for Papers
+
+The 2017 Workshop on Visualization in Practice (VIP) is an opportunity for visualization practitioners and researchers to meet and share experiences, insights, and ideas in applying the latest visualization and visual analytics research to real world problems. VIP targets work at the interface between visualization research and specific application domains. It is highly interdisciplinary and focused on delivering actual value to users. This year, we specifically focus on *visualization solutions in the wild*, i.e. on tools, systems, or frameworks which are actively used. The workshop will cover all aspects from their initial conception and design, the process of getting them into use, and the long-term work of extending and sustaining them. 
+
+The 2017 VIP workshop will be held on 2nd October in conjunction with IEEE VIS in Phoenix, Arizona (October 01-06). 
+
+## Topics
+
+Vis in Practice is a forum for vis practitioners and application-oriented researchers to exchange ideas about the use of state-of-the-art visualization and visual analytics methods on real world problems. This year, we are looking for descriptions of visualization solutions that have proven their benefit in a real-world application setting. Successful submissions will put a strong focus on demonstrating practical impact in a variety of ways, including but not limited to:
+
+* **user involvement** - The goal of a practical visualization solution should be to address a specific visualization and/or problem posed by a prospective user group, oftentimes experts from other domains. Interaction with users is tricky; they frame their analysis problem in their own terms, which are often nontrivial for visualization experts to understand, and they may find it hard to gauge how their work can benefit from state-of-the-art visualization methods. This leads to interesting questions: How do we involve users throughout the development? How can we understand their problem domains? How do we communicate the added value of modern visualization approaches? Can we identify best practices that transcend specific applications?
+
+* **application-driven design** - Generally, no uniquely defined, “correct” approach exists for any given visualization problem. Developing a working solution requires identifying viable options, weighing them, and eventually selecting a small subset. To this end, authors might answer these questions: What process did you follow to design your solution? Did you use specific visualization methodologies or visualization-theoretic models? What design decisions did you face? What options did you consider? How did you make a selection? How did your solution improve the existing situation? 
+
+* **systems aspects** - Oftentimes, solutions will be a large system rather than a one-method, fire-and-forget approach. Such systems generally require a lot of infrastructure building, a major development effort in its own right. How can we manage this extra effort? How can we make solutions sustainable? Should we consider an open, community-based development approach?
+knowledge transfer - Practical visualization solutions will by definition live on the interface between visualization research and a specific application domain. Their development will be driven by an exchange of knowledge across this interface. What does it take to transfer an existing visualization method from a lab setting to a specific application problem? What pitfalls might we encounter? How can we overcome them? What parts of the problem remain challenging? Are there open problems that warrant more attention by the visualization research community?
+
+Although we do not expect individual submissions to cover all of these aspects, successful papers will feature a strong take-home message for a visualization-centric audience. We ask authors to contribute something beyond a “user manual” for a solution targeting a narrow application use case.
+
+## Submission
+We solicit submissions of extended abstracts of up to four pages excluding references. Submissions should be prepared according to the IEEE conference paper format guidelines (http://junctionpublishing.org/vgtc/Tasks/camera.html).
+Optionally, you may submit a video (MPEG, AVI, or Quicktime format, duration at most 5 minutes) showing your application or methods in action. This will be most helpful for demonstrating the effectiveness of your approach. If you would like to have your video included in the conference USB stick, it should not exceed 100MB.
+
+Abstracts will be reviewed for their potential applicability to the VIP workshop audience and their potential impact on the visualization community at large. Additionally, they will be reviewed for timeliness, clarity, and overall quality of writing. Note that research novelty is explicitly not the primary criterion for evaluation at the VIP workshop.
+Based on the outcome of the review process, authors of successful submissions will be invited to either present their work in a talk during the Vis in Practice workshop on October 2 or to prepare a poster for the VIP poster session, which will be held along with the VIS main poster session on October 4.
+
+All submissions for the 2017 Workshop on Visualization in Practice should be submitted via the Precision Conference System. Submissions must be received on or before June 16, 2017 to be considered. Questions about this workshop or requests for help with submission problems can also be sent to vip@ieeevis.org.
+In order to maintain interactive and exciting presentations and posters, we require that at least one presenter per accepted submission attend the workshop.
+
+## Important Dates 
+* Submission Deadline: June 16, 2017
+* Notification of Acceptance: July 14, 2017
+* Final Submission (Camera-ready): July 26, 2017
+* Workshop presentations: October 2, 2017
+* Workshop poster session: October 4, 2017
+
+## Publication
+All submitted abstracts and the accompanying material will be published in the IEEE digital library and on the IEEE Vis conference USB stick. Selected submissions will be invited to submit an extended manuscript to a special issue of IEEE Computer Graphics and Applications on “Applied Visualization” due to be published in May 2018.
+
+## Organizers
+Bernd Hentschel - RWTH Aachen University
+Daniela Oelke - Siemens AG
+Justin Talbot - Tableau Research
+


### PR DESCRIPTION
This is a first version of the CfP for this year's Vis in Practice event. It is meant to get the essential info for the event out there. We will fill in more details in a subsequent release, specifically:
* submission page on PCS
* link to the event's home page
* and (optionally) IPC