### PR TITLE
Update workshops.md

### DIFF
--- a/year/2017/info/workshops.md
+++ b/year/2017/info/workshops.md
@@ -6,10 +6,11 @@ contact: "workshops@ieeevis.org"
 ---
 
 * Immersive Analytics: Exploring Future Visualization and Interaction Technologies for Data Analytics
+* Discovery Jam
+* DSIA 2017: Data Systems for Interactive Analysis
 * 2nd Workshop on Visualization for the Digital Humanities
 * DECISIVe 2017: 2nd workshop on dealing with cognitive biases in visualizations
 * Visual Analytics for Interpretable, User-Drive Deep Learning
 * Innovations in the Pedagogy of Data Visualization
 * BPViz: Broadening Participation in Visualization Workshop
 * Vis In Practice
-


### PR DESCRIPTION
added two missing workshops from the list

Also, "Vis in Practice" is not a workshop that we reviewed. How was this added?