### PR TITLE
Update vast-program-committee.md

### DIFF
--- a/year/2017/info/committees/vast-program-committee.md
+++ b/year/2017/info/committees/vast-program-committee.md
@@ -9,7 +9,7 @@ contact: vast_papers@ieeevis.org
 | Gennady Andrienko | Fraunhofer IAIS |
 | Natalia Andrienko | Fraunhofer IAIS |
 | Daniel Archambault | Swansea University |
-| Michele Aupetit | Qatar Computing Research Institute |
+| Michael Aupetit | Qatar Computing Research Institute |
 | Peter Bak | IBM Research Lab, Haifa |
 | Fabian Beck | University of Duisburg-Essen |
 | Alessio Bertone | TU Dresden |


### PR DESCRIPTION
there is a typo in my name on the program committee page: It should be: “Michael Aupetit” instead of “Michele Aupetit”