### PR TITLE
changed vis in practice link to point to new, working website

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -67,7 +67,7 @@
 	    <li><a href="http://sciviscontest-staging.ieeevis.org/">SciVis Contest</a></li>
       <li><a href="http://biovis.net/2017/ieeevis/">BioVis Challenge</a></li>
 	    <li><a href="http://visap.uic.edu/2017/callforentries.html">VIS Arts Program</a></li>
-	    <li><a href="http://visinpractice.org/">VIP: Visualization in Practice</a></li>
+	    <li><a href="http://www.visinpractice.rwth-aachen.de/index.html">VIP: Visualization in Practice</a></li>
 	    <li><a href="/year/2017/info/exhibition/viskids-child-care-grants">VisKids</a></li>
 	    <li>Velo Club de VIS</li>
 	    <li>Vis Pioneers Group</li>


### PR DESCRIPTION
Dear Carlos,

**TL:DR**: I pointed the nav bar to the new ViP website. Could you please merge and deploy *ASAP*?

We have been trying to migrate the "old" URL visinpractice.org to my new provider. Albeit being standardized, this process has twice failed over the last two weeks. This resulted in significant downtime for visinpractice.org, something that we cannot afford with just over a week until the deadline. Therefore, I now hard-linked the nav bar to the new site, which at least gives us a valid entry point through ieeevis.org. We are working with both providers to get this settled asap. For now, this is the quickest hot fix I see.

Thanks in advance!

Bernd