### PR TITLE
Add active links to community and participant information

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -45,8 +45,8 @@
 	    <li><a href="/year/2017/info/call-participation/workshops">Workshops</a></li>
 	    <li><a href="/year/2017/info/call-participation/panels">Panels</a></li>
 	    <li><a href="/year/2017/info/call-participation/doctoral-colloquium">Doctoral Colloquium</a></li>
-            <li>Meetups</li>
-	    <li>Community</li>
+	    <li>Meetups</li>
+	    <li><a href="/year/2017/info/call-participation/community">Community</a></li>
 
 	  </ol>
 	</div>
@@ -82,6 +82,8 @@
         <h3 class="menu-title">Participant Information</h3>
 	  <ol class="link-leftbar">
 	    <li><a href="/year/2017/info/presenter-information/fast-forward-and-video-previews">Fast Forward and Video Previews</a></li>
+	    <li><a href="/year/2017/info/call-participation/community#vis-buddies">Vis Buddies</a></li>
+	    <li><a href="/year/2017/info/call-participation/community#asynchronous-job-fair">Job Fair</a></li>
 	  </ol>
 	</div>
 	      


### PR DESCRIPTION
We need to activate the link to the Community page and also add links to the Vis Buddies and Job Fair on the participant information.