### PR TITLE
Fixed tutorial sessions link

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -35,7 +35,7 @@
 	    <li><a href="">Posters</a></li>	  
 	    <li><a href="">VAST Challenge</a></li> -->	  
 	    <li><a href="/year/2017/info/workshops">Workshops</a></li>	  
-	    <li><a href="/year/2017/info/call-participation/tutorials">Tutorials</a></li>  	    
+	    <li><a href="/year/2017/info/tutorials">Tutorials</a></li>  	    
 	    <!--- <li><a href="">Panels</a></li>	  
 	    <li><a href="">Doctoral Colloquium</a></li>	  
 	    <li><a href="">Meetups</a></li>


### PR DESCRIPTION
Session link went to CFP instead of list of accepted tutorials. Fixed.