### PR TITLE
Create bids.md

### DIFF
--- a/year/2017/info/committees/bids.md
+++ b/year/2017/info/committees/bids.md
@@ -1,0 +1,173 @@
+---
+title: VIS Bid Guidelines
+layout: main-2017
+permalink: /year/2017/info/committees/bids
+---
+
+VIS welcomes bids for future conferences, to be submitted to the VEC (VIS Executive Committee). Currently, we
+have decided on 2015 through 2020, and are accepting bids for 2021 and onwards.
+
+## Ground Rules
+* Bidders have flexibility on how to assign roles and responsibilities in multi-person teams. One model is to
+specify only one General Chair (GC) so that there is a single extremely clear point person of ultimate
+responsibility, with multiple supporting chairs. Another model is to have two (or more) General Co-Chairs.
+A single General Chair is a third viable model.
+*  We welcome bids from outside of the continental United States.
+* The bid can be for a different city than where the General Chair lives, to open up the chair-ship to people
+who live in places that are not amenable for hosting large conferences. (New policy as of 2014)
+* We now actively encourage the use of conference center rather than hotel locations to accommodate future
+growth. (New policy as of 2014)
+* The proposed date should be within October if at all possible, ideally the second, third, or fourth week.
+There are many schedule constraints. Try hard to avoid secular and religious holidays including Halloween
+(Oct 31) and the major Jewish holidays (different times each year). Avoid conflicts with other major
+conferences, including the week of Supercomputing and the week before it, and the exact week of UIST.
+The first two weeks of November are fallback possibilities.
+* The ideal hotel room pricing is below $200/night; however, note that in large "Tier 1" cities that target is
+not realistic, so there is a tradeoff between city desirability and cost to consider in framing your bid. Avoid
+airport hotels, as they do not offer a vibrant experience and attendees consider it a “bait and switch”
+compared to city centers.
+* Further information on the bid process is in Section IV of the VEC Charter, and further information on how
+the roster of front-line organizers is determined in conjunction between the VEC, the conference steering
+committees, and the GCs is in the Appendix. See http://ieeevis.org/attachments/vec_charter.pdf
+* In 2017 the VEC Chair is Tamara Munzner (vec_chair@ieeevis.org) and the IEEE Liaison is Nicole Finn
+(eventplanner@ieeevis.org). The full VEC (vec@ieeevis.org) membership is listed at
+http://ieeevis.org/year/2017/info/committees/vis-executive-committee
+* In the schedule below, one week means five business days (Monday to Friday).
+
+## Procedure Overview
+
+| Step | Who | What | Deadline | Turnaround |  
+| ---- | -------------- | ----------- | -------------------- | ------------ |
+| 0 | Bidder | Initiate | |
+| 1 | VEC | Screen | | 3 months |  
+| 2 | VEC Chair | Connect | | 1 week |  
+| 3 | IEEE Liaison | Request | | 5 weeks |  
+| 4 | Bidder | Create | | |  
+| 5 | Bidder | Submit | Sep 1 Y3 (or Y2) | |  
+| 6 | VEC | Decide | Dec 1 Y3 (or Y2) | |  
+| 7 | Liaison | Release/Confirm | Dec 15 Y3 (or Y2) | 2 weeks |  
+| 8 | Liaison+Staff | Negotiate | Apr 1 Y3 (or Y2) | 12 weeks |  
+| 9 | Liaison+Staff | Site Visit 1 | parallel w/ 7 | | 
+| 10 | Finance/General | Forms | parallel w/ 7-10 | | 
+| 11 | Staff | Approve | Apr 15 Y2 (or Y1) | 2 weeks |  
+| 12 | IEEE Legal | Sign | Jun 1 Y2 (or Y1) | 4 or 6 weeks |  
+| 13 | Liaison+Staff | Additions | Mar Y1, Mar Y0 | |  
+| 14 | Liaison+Staff | Site Visit 2 | Apr Y0 | |  
+| 15 | All | Conference | Oct Y0 | |  
+
+## Procedure Details
+
+0. **Bidder: Initiate.** Inform the VEC Chair of your intent to put together a bid, by submitting a brief document
+detailing the experience of the general chair and any other people who are part of the bid. Start with your past
+engagement with VIS as attendees, contributors, reviewers, program committee members, and all organizational
+roles, being specific about what years you served in what roles. Also include any other substantial organizational
+experience at other venues including conferences/workshops and journals in roles such as associate editor or guest
+editor. *(New policy as of 2016)*
+
+1. **VEC: Screen.** The VEC Chair will send your initiation document to the VEC, which will consider whether you
+and your team are a good fit to go forward with the process in terms of experience and qualifications. At some times
+of year there may be fast turnaround if multiple bidders are expressing interest (close to or during the VIS
+conference), but at other times there may be a delay until the next VEC teleconference can be scheduled.  
+**Turnaround time: 3 months.** *(New policy as of 2016)*
+
+2. **VEC Chair:** Connect. For bids within North America, put bidder in touch with the IEEE Liaison to VIS who will
+initiate the engagement with venues in the target city. For bids in cities outside of North America, send bidder the
+current standard template that the IEEE Liaison uses for venue engagement as a source of logistics information.  
+**Turnaround time: 1 week.**
+
+3. **IEEE Liaison: Request.** *(North American bids only)* Send out a customized RFP (Request For Proposals) to
+venues in your target city. It will be based on the standard RFP template, which has already been vetted by the
+finance and program chairs and includes information on meeting room size requirements, room rates, wifi,
+food/beverage, student volunteer rooms, hotel rebates if held at convention center, and other logistics issues that
+most prospective general chairs will not be deeply familiar with. Having the IEEE Liaison in the loop from the very
+beginning of initial contact with venues will make the later contract negotiation phase (step 10) go much faster. The
+Liaison will collect all of the venue responses and forward them in a single batch to the bidder CC the VEC Chair.
+Bidders outside North America are also welcome to request RFP support from the IEEE Liaison, but the financial
+and logistical landscape outside of North America is sufficiently different that bidders may choose to investigate
+options themselves. In that case, the expectation is not that the exact equivalent of RFP responses would be
+submitted by bidders outside North America, given that the hotel situation is quite different. The template is simply
+a source of useful information. There is flexibility on the format according to the situation of the bidders, as
+discussed in step 5 below.  
+**Turnaround time: 5 weeks.** The Liaison will send out the RFPs to the venues within one week of hearing from the
+VEC Chair, with a two-week cutoff date for the venues to respond. The Liaison will forward the full set of responses
+within two weeks of that date.
+
+4. **Bidder: Create.** Create your proposal, incorporating information from the venue responses. Visit the venues in
+person if possible as part of your decision making process. Issues that you should consider and document include the
+following: hotel room costs, local transit, eateries within walking distance, likelihood of walk-in attendees from that
+city/region who don't typically attend, likelihood of sponsorship from organizations who don't typically sponsor
+(including local and national governments). Also include costs and ease/availability of transportation to the city, and
+desirability of city as a destination in itself (a double-edged sword, as more desirable places tend to have higher
+costs). If multiple people are named in the bid, either as general chairs plus supporting chairs or as general co-chairs,
+then include a section on decision-making and responsibilities to discuss plans for communication and the division
+of responsibilities.  
+Bids from within North America do not need to address budget questions beyond these issues. Bids from outside the
+US should address visa requirements, tax/VAT issues (including whether a VAT exemption is possible through a
+local university), and contain budget projections including expected gains and losses in attendees and sponsorship
+from the within-US case. Non-US bidders may need to work with the finance chairs to understand budget issues.  
+**Turnaround time: up to you.**
+
+5. **Bidder: Submit.** Submit the bid to the VEC Chair, who will forward it to the rest of the VEC for consideration.  
+**Deadline: September 1 Y3 or Y2.** Bid should be received a minimum of 25 months (one month before the VIS two
+years in advance) of the proposed conference. Earlier bids are strongly encouraged, ideally three years + 1 month in
+advance.
+
+6. **VEC: Decide.** The VEC will discuss the bids, possibly waiting until multiple proposals have been received, and
+make a decision. The VEC Chair will inform the successful bidder, who becomes the General Chair (GC), and also
+inform the IEEE Liaison. The VEC Chair will also inform Steering Committee members.  
+**Deadline: December 1 Y3 or Y2.** Decision should be made at least 22 months in advance of the conference (two
+months after VIS two years in advace), and ideally three years in advance.
+
+7. **Liaison: Release/Confirm.** IEEE Liaison releases options for un-chosen venues. IEEE Liaison confirms with the
+chosen venue that it has been selected and that final contract negotiations will now begin.  
+**Turnaround time: 2 weeks.**  
+**Deadline: Dec 15 Y3 or Y2.**
+
+8. **Liaison: Negotiate.** IEEE Liaison is responsible for negotiating the venue (hotel or convention center) contract
+and obtaining all required documentation for contract submission to the IEEE Contracts Department. Key staff
+(General, Finance, Program) will be included in this process.  
+**Turnaround time: 3 months (90 business days).** Timing is January through March, losing a few weeks with few
+business days available over the winter holidays.  
+**Deadline: Apr 1 Y2 or Y1**
+
+9. **Key Staff: Site Visit 1.** For the chosen bid, there will be an initial site inspection with Program Chairs, the
+General Chair, Finance Chairs, and IEEE Liaison. The AV contractor might also join for this visit.  
+**Deadline: spring Y2 or Y1.** Steps 8-10 run in parallel. The site visit should take place between January and March,
+the earlier the better.
+
+10. **Finance/General: Forms.** The finance chairs will begin work on creating the conference application form,
+which must be endorsed by the VGTC Chair before being submitted to the IEEE. The General Chair must also
+submit the COI (Conflict of Interest) form to the IEEE.  
+**Deadline: Apr 15 Y2 or Y1.** Steps 8-10 run in parallel. Both of these forms must be submitted to the IEEE before
+sending the contract to Legal for signing (step 11).
+
+11. **Staff: Approve.** IEEE Liaison will send a copy of final hotel/convention center contract to that conference year's
+General Chair, Finance Chair and Program Chair for their review and final approval.
+**Turnaround time: 2 weeks**  
+**Deadline: April 15 Y2 or Y1 (18 months before conference minimum)**
+
+12. **IEEE: Sign.** IEEE Liaison sends the finalized contract to IEEE Legal. 10A. IEEE Liaison sends approved
+hotel/convention center contract(s) to the IEEE Contracts Team for review, processing and signature.
+**Turnaround Time for IEEE Liaison: 3 business days (once approvals are received)**  
+**Turnaround Time for IEEE Contracts/Legal Team: 4 weeks for domestic contracts or 6 weeks for
+international contracts** (except during the Nov/Dec blackout period when contract should not be sent to the IEEE
+Contracts team unless deeply urgent).  
+**Deadline: Jun 1 Y2 or Y1 (17 months before conference minimum)**
+
+13. **Staff + Liaison: Additions.** General Chair, Program Chairs, Finance Chairs and IEEE Liaison will revisit the
+contract annually to consider addenda based on lessons learned from the latest VIS, including whether to keep the
+ROFR (right of first refusal) space that we had originally reserved in case of attendance growth.  
+**Deadline: By March Y1 (No later than Q1 of the following conference year).**
+
+14. **Staff + Liaison: Site Visit 2.** Second site visit with Program Chairs, General Chair, Finance Chairs, AV
+contractor, and IEEE Liaison.  
+**Deadline: By April Y0 (6 months before conference).**
+
+15. **All: Conference.**
+**Deadline: October Y0.**
+
+## Change Log
+* 26 Sep 2017 - Converted to markdown, update years approved & email addresses
+* 15 Nov 2016 - Further amendments approved by VEC
+* 24 October 2016 - Amendments approved by VEC
+* 5 August 2015 - Approved by VEC


### PR DESCRIPTION
The question is how to handle these documents in terms of menu structure. I'd like to see them as sub-items under the VEC. This will replace the former PDF file, it's better to have this as a real thing in markdown that can get updated incrementally. I'd like to both have an index at the bottom of the VEC page, and to have them as subitems in the menu. There's also another new file, coordination.md, which should also be a subitem. 