### PR TITLE
adding gitattributes for windows dev

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# set the default behavior (even if individuals do not have core.autocrlf set)
+* text=auto
+
+# scripts should always have LF endings on checkout (esp. important for those using Windows Subsystem for Linux to build)
+# for info on linux subsystem, see <https://msdn.microsoft.com/en-us/commandline/wsl/install-win10>.
+*.sh text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
Setting my environment up on Windows, I found that using the [Linux Subsystem for Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install-win10) was pretty straightforward.  I'd also be happy to write up how I set up my environment :)

Some changes so that `*.sh` scripts are always checked out with `\n` line endings instead of the Windows Git default of `\r\n`.

Making this a PR because I'm not positive if this breaks any automated tasks (don't have permissions to check).

