### PR TITLE
add link to practitioner guide

### DIFF
--- a/_includes/left_sidebar-2018.html
+++ b/_includes/left_sidebar-2018.html
@@ -25,8 +25,9 @@
 	  <ol class="link-leftbar"> 
 	<!--    <li><a href="/attachments/VIS2018_AAG.pdf">VIS2018 AT-A-GLANCE</a></li> -->
 	    <li><a href="/attachments/vis18-program.pdf">Full Program</a></li>
-	    <li><a href="/attachments/vis18-badgeinsert.pdf">Pocket Program</a></li>
-	    <li><a href="/year/2018/keynote">Keynote Address</a></li>
+			<li><a href="/attachments/vis18-badgeinsert.pdf">Pocket Program</a></li>
+			<li><a href="http://www.visinpractice.rwth-aachen.de/guide.html">Practitioner Guide</a></li>
+			<li><a href="/year/2018/keynote">Keynote Address</a></li>
 	    <li><a href="/year/2018/capstone">Capstone Address</a></li>
 	    <li><a href="/year/2018/info/papers">Accepted Papers List</a></li>
             <li><a href="/year/2018/info/papers-sessions">Papers Sessions</a></li>


### PR DESCRIPTION
I just added a forward link to the Practitioner Guide which is hosted on the Vis In Practice web page for this year. Feel free to check out the content there before staging this. With VIS approaching fast, we'd appreciate a fast deployment.