### PR TITLE
Enable the Student Volunteers entry on the left_sidebar-2019

### DIFF
--- a/_includes/left_sidebar-2019.html
+++ b/_includes/left_sidebar-2019.html
@@ -157,15 +157,13 @@
 	    <!--   </ol> -->
 	  <!-- </div> -->
 
-	<!-- <div>
+	<div id="sv-leftbar" class="_blank">
 	  <h3 class="menu-title">Student Volunteers</h3>
-	  <ol class="link-leftbar"> -->
-	    <!-- <li><a href="http://vissv.org">Information</a></li> -->
-	    <!-- <li><a href="https://goo.gl/forms/O0O2Zfeq6MDcYcU83">SV Application</a></li>	  -->
-	    <!-- <li><a href="http://vissv.org/shirtcontest.html">T-Shirt Design Contest</a></li>	  -->
-	    <!-- <li><a href="/year/2017/info/overview-amp-topics/student-volunteer-directory">SV Directory</a></li> -->
-	  <!-- </ol>
-	</div> -->
+	  <ol class="link-leftbar">
+	     <li><a href="http://vissv.org" target="_blank">Information</a></li> 
+	     <li><a href="http://vissv.org/shirtcontest.html" target="_blank">T-Shirt Design Contest</a></li>
+	  </ol>
+	</div>
 	
 	<div id="committee-leftbar">
 	  <h3 class="menu-title">Committees</h3>


### PR DESCRIPTION
The SV program is about to start the first event (T-shirt design contest) for this year. We hope to enable the SV entry to get more visibility for this event. 

P.S., I notice that each item on the left-sidebar has an id and a class="_blank". I'm not very sure what they do, but I followed the format. 

-Fumeng Yang