### PR TITLE
Add D&I statements

### DIFF
--- a/_includes/left_sidebar-2019.html
+++ b/_includes/left_sidebar-2019.html
@@ -134,8 +134,8 @@
 	<div id="equity-leftbar" class="_blank">
 	  <h3 class="menu-title">Equity, Inclusion, & Diversity</h3>
 	  <ol class="link-leftbar"> 
-	    <!-- <li><a href="">IEEE Computer Society Open Conference Statement</a></li> --> 
-	    <!-- <li><a href="">IEEE Event Conduct and Safety Statement</a></li> -->
+	    <li><a href="/year/2019/info/inclusion-and-diversity/open-conference">IEEE Computer Society Open Conference Statement</a></li> 
+	    <li><a href="/year/2019/info/inclusion-and-diversity/event-conduct-safety">IEEE Event Conduct and Safety Statement</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/code-of-conduct">IEEE VIS Code of Conduct</a></li>      
 	  </ol>
 	</div>

--- a/year/2019/info/inclusion-and-diversity/code-of-conduct.md
+++ b/year/2019/info/inclusion-and-diversity/code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-title: IEEE VIS Code of conduct
+title: IEEE VIS Code of Conduct
 layout: main-2019
 permalink: /year/2019/info/inclusion-and-diversity/code-of-conduct
 ---

--- a/year/2019/info/inclusion-and-diversity/diversity-scholarship.md
+++ b/year/2019/info/inclusion-and-diversity/diversity-scholarship.md
@@ -13,7 +13,9 @@ The VIS 2019 Inclusivity & Diversity Scholarship Committee will review applicati
 
 ### Application and Timeline:
 
-* Application form (posted early summer 2019) 
+* Applications form (will be posted May 1, 2019)
+* Deadline: June 30, 2019
+* Notifications Sent: August 1, 2019
 
 ### Contact
 

--- a/year/2019/info/inclusion-and-diversity/event-conduct-safety.md
+++ b/year/2019/info/inclusion-and-diversity/event-conduct-safety.md
@@ -1,0 +1,11 @@
+---
+title: IEEE Event Conduct and Safety Statement
+layout: main-2019
+permalink: /year/2019/info/inclusion-and-diversity/event-conduct-safety
+---
+
+IEEE believes that science, technology, and engineering are fundamental human activities, for which openness, international collaboration, and the free flow of talent and ideas are essential. Its meetings, conferences, and other events seek to enable engaging, thought provoking conversations that support IEEE’s core mission of advancing technology for humanity. Accordingly, IEEE is committed to providing a safe, productive, and welcoming environment to all participants, including staff and vendors, at IEEE-related events.
+ 
+IEEE has no tolerance for discrimination, harassment, or bullying in any form at IEEE-related events. All participants have the right to pursue shared interests without harassment or discrimination in an environment that supports diversity and inclusion. Participants are expected to adhere to these principles and respect the rights of others.
+ 
+IEEE seeks to provide a secure environment at its events. Participants should report any behavior inconsistent with the principles outlined here, to on site staff, security or venue personnel, or to [eventconduct@ieee.org](mailto:eventconduct@ieee.org).

--- a/year/2019/info/inclusion-and-diversity/open-conference.md
+++ b/year/2019/info/inclusion-and-diversity/open-conference.md
@@ -1,0 +1,11 @@
+---
+title: IEEE Computer Society Open Conference Statement
+layout: main-2019
+permalink: /year/2019/info/inclusion-and-diversity/open-conference
+---
+
+Equity, Diversity, and Inclusion are central to the goals of the IEEE Computer Society and all of its conferences. Equity at its heart is about removing barriers, biases, and obstacles that impede equal access and opportunity to succeed. Diversity is fundamentally about valuing human differences and recognizing diverse talents. Inclusion is the active engagement of Diversity and Equity.
+ 
+A goal of the IEEE Computer Society is to foster an environment in which all individuals are entitled to participate in any IEEE Computer Society activity free of discrimination. For this reason, the IEEE Computer Society is firmly committed to team compositions in all sponsored activities, including but not limited to, technical committees, steering committees, conference organizations, standards committees, and ad hoc committees that display Equity, Diversity, and Inclusion.
+ 
+IEEE Computer Society meetings, conferences and workshops must provide a welcoming, open and safe environment, that embraces the value of every person, regardless of race, color, sex, sexual orientation, gender identity or expression, age, marital status, religion, national origin, ancestry, or disability. All individuals are entitled to participate in any IEEE Computer Society activity free of discrimination, including harassment based on any of the above factors.


### PR DESCRIPTION
This PR adds the IEEE Computer Society Open Conference and IEEE Event Conduct and Safety Statements, and posts the timeline for the diversity scholarship. 