### PR TITLE
Update and rename awards to best-paper-awards.md

### DIFF
--- a/year/2019/info/best-paper-awards.md
+++ b/year/2019/info/best-paper-awards.md
@@ -1,0 +1,58 @@
+---
+title: Best Paper Awards
+layout: main-2019
+permalink: /year/2019/info/awards/best-paper-awards
+---
+Best paper and honorable mention awards are selected per conference track by a dedicated committee of experienced community members. 
+Both awards recognize outstanding work from the pool of accepted papers in each conference track.  
+Best paper committees use a variety of criteria to select the best paper including potential impact to the community, 
+the importance of any results obtained, technical challenges overcome, etc. 
+Generally only one best paper is selected per conference track each year and up to three honorable mention awards.
+
+
+## VAST
+
+### Best Paper Award
+
+**FlowSense: A Natural Language Interface for Visual Data Exploration within a Dataflow System**
+<br/>
+Authors: Bowen Yu, Claudio Silva
+
+### Best Paper Honorable Mention
+
+**NNVA: Neural Network Assisted Visual Analysis of Yeast Cell Polarization Simulation**
+<br/>
+Authors: Subhashis Hazarika, Haoyu Li, Ko-Chih Wang, Han-Wei Shen, Ching-Shan Chou
+
+**Supporting Analysis of Dimensionality Reduction Results with Contrastive Learning**
+<br/>
+Authors: Takanori Fujiwara, Oh-Yun Kwon, Kwan-Liu Ma
+
+
+## InfoVis
+
+### Best Paper Award
+
+**Data Changes Everything: Challenges and Opportunities in Data Visualization Design Handoff**
+<br/>
+Authors: Jagoda Walny, Christian Frisson, Mieka West, Doris Kosminsky, Søren Knudsen, Sheelagh Carpendale, Wesley Willett
+
+### Best Paper Honorable Mention
+
+**xxxxx**
+<br/>
+Authors: yyyyy
+
+## SciVis
+
+### Best Paper Award
+
+**InSituNet: Deep Image Synthesis for Parameter Space Exploration of Ensemble Simulations**
+<br/>
+Authors: Wenbin He, Junpeng Wang, Hanqi Guo, Ko-Chih Wang, Han-Wei Shen, Mukund Raj, Youssef S. G. Nashed, Tom Peterka
+
+### Best Paper Honorable Mention
+
+**xxx**
+<br/>
+Authors: yyy


### PR DESCRIPTION
Please add to staging, but we need a new "Awards" subheading in the left navigation bar, similar to 2018.