### PR TITLE
Create best-poster-awards.md

### DIFF
--- a/year/2019/info/awards/best-poster-awards.md
+++ b/year/2019/info/awards/best-poster-awards.md
@@ -1,0 +1,57 @@
+---
+title: Poster Awards
+layout: main-2019
+permalink: /year/2019/info/awards/best-poster-awards
+---
+The best poster awards and honorable mentions are assigned by dedicated committees per poster track. Experienced researchers in the committees provided individual assessments for a selection of the most promising poster candidates made by the poster co-chairs of each track. Based on these assessments the awardees were chosen.  
+
+New this year is the best presentation award which will be assigned to a poster that is excellent regarding effective use of poster format, design, and aesthetics by the VIS 2019 poster co-chairs during the course of the conference.
+
+This year’s awardees are:
+
+## VAST
+
+### Best Poster 
+
+**Visual Analytics of Student Learning Behaviors on K-12 Mathematics E-learning Platforms**
+<br/>
+Meng Xia, Mr Huan Wei, Min XU, Leo Yu Ho Lo, Yong Wang, Rong Zhang, Huamin Qu
+
+### Honorable Mention
+
+**Visual Analytics for Integrated Evolution of Physical and Cyber-Events: A Case of the World Cup in Social Media**
+<br/>
+Siming Chen, Xing Gao, Jie Li, Gennady Andrienko, Natalia Andrienko
+
+## InfoVis
+
+### Best Poster
+
+**Exploring Cheat Sheets for Data Visualization Techniques**
+<br/>
+Zezhong Wang, Lovisa Sundin, Dave Murray-Rust, Benjamin Bach
+
+### Honorable Mentions
+
+**A Qualitative Assessment of Basic Perceptual Tasks Employed While Reading Common Data Visualizations**
+<br/>
+Caitlyn McColeman, Enrico Bertini, Steven Franconeri
+
+**Automatic Annotation of Visualizations**
+<br/>
+Chufan Lai, Zhixian Lin, Can Liu, Yun Han, Ruike Jiang, Xiaoru Yuan 
+
+**Arctic Explorer: Visualization of Sea-Ice Concentration along Arctic Shipping Routes**
+<br/>
+Dylan Wootton, Ethan Ransom, Alexander Lex
+
+## SciVis
+
+### Best Poster 
+
+**Linked View Visualization Using Clipboard-Style Mobile VR: Application to Communicating Forestry Data**
+<br/>
+Jung Who Nam, Charles Hobie Perry, Barry Ty Wilson, Daniel F. Keefe 
+
+## Best Poster Presentation Award
+- to be announced


### PR DESCRIPTION
as a response to several requests we propose a web page for poster awards (awardees + process) similar to the best paper awards page. we (poster co-chairs) would appreciate if it can be shown similarly to best paper awards under side bar "Awards and Recognitions". Attaching the information to the existing best paper awards page would also be fine. thx