### PR TITLE
Fixing link to ethics guidelines

### DIFF
--- a/content/info/call-participation/review-instructions.md
+++ b/content/info/call-participation/review-instructions.md
@@ -8,7 +8,7 @@ sidebar: call-for-participation
 
 **Updated 6 April 2020**
 
-The success of the IEEE VIS 2020 papers program relies on a knowledgeable, experienced, and ethical community of reviewers. IEEE VIS 2020 employs a two-phase, [(author-optional) double-blind review](paper-submission-guidelines#important-submission-requirements) process that follows the review process for IEEE TVCG, the journal in which most IEEE VIS full papers are published. All papers are reviewed by at least 4 reviewers, at least 2 of which are IPC members and at least 2 of which are external members of the community. All reviewers are bound to the [ethics guidelines of the IEEE VGTC](http://vgtc.org/about-us/conferences/ethics-guidelines).
+The success of the IEEE VIS 2020 papers program relies on a knowledgeable, experienced, and ethical community of reviewers. IEEE VIS 2020 employs a two-phase, [(author-optional) double-blind review](paper-submission-guidelines#important-submission-requirements) process that follows the review process for IEEE TVCG, the journal in which most IEEE VIS full papers are published. All papers are reviewed by at least 4 reviewers, at least 2 of which are IPC members and at least 2 of which are external members of the community. All reviewers are bound to the [ethics guidelines of the IEEE VGTC](http://vgtc.org/conferences/ethics-guidelines).
 
 This page provides detailed instructions for both IPC reviewers and external reviewers.
 
@@ -68,7 +68,7 @@ If you have not yet updated your keywords then see the [Keywords Update](#keywor
 
 4. Click on "Conflicts".
 
-5. Click the checkbox beside each author with whom you are in conflict.  The checkbox will flash green to indicate that your conflict has been recorded.  There is no submit button on this page.  You can type an institution name in the "Search" box in the upper-right corner to show people from a particular institution.  For guidance on reviewer conflicts-of-interest please see the [IEEE VGTC ethics guidelines for reviewers](http://vgtc.org/about_us/conferences/ethics-guidelines).
+5. Click the checkbox beside each author with whom you are in conflict.  The checkbox will flash green to indicate that your conflict has been recorded.  There is no submit button on this page.  You can type an institution name in the "Search" box in the upper-right corner to show people from a particular institution.  For guidance on reviewer conflicts-of-interest please see the [IEEE VGTC ethics guidelines for reviewers](http://vgtc.org/conferences/ethics-guidelines).
 
 6. Click on the VAST/InfoVis/SciVis tab under the Reviews tab to return to your main reviewing page.
 
@@ -192,7 +192,7 @@ All reviewers should make sure to follow the basic principles outlined below. As
 * Find reasons to accept papers: have an open-mind or at least disclose your biases. It is easier to find reasons to reject papers than to point out the contributions that they bring to the community. Emphasize positive aspects to help surface impactful research to the community.
 * Be tactful and polite: emotional rants or sarcastic comments have no place in a professional review. Ask yourself if you could read your review aloud in front of an audience including the authors.
 
-Additionally, all reviewers are bound to the [ethics guidelines of the IEEE VGTC](http://vgtc.org/about-us/conferences/ethics-guidelines). Please make sure you are familiar with these guidelines.
+Additionally, all reviewers are bound to the [ethics guidelines of the IEEE VGTC](http://vgtc.org/conferences/ethics-guidelines). Please make sure you are familiar with these guidelines.
 
 ## What is a minor revision?
 All IEEE VIS acceptances are conditional after the first round of reviewing, after which authors will be asked to perform a minor revision on the paper. While a select few papers do not require any changes at all, this is very rare. In other words, reviewing in the first round becomes one of deciding which papers will be acceptable for publication after a minor revision. No paper is perfect; rather, your job is to identify the work that will have a significant contribution to visualization after the authors get a period of four weeks to address reviewer comments.


### PR DESCRIPTION
The current link to ethics guidelines does direct to a valid page.  

Changes from: http://vgtc.org/about-us/conferences/ethics-guidelines
To: http://vgtc.org/conferences/ethics-guidelines

In 3 places.