### PR TITLE
Update final-information-paper-authors.md

### DIFF
--- a/content/info/presenter-information/final-information-paper-authors.md
+++ b/content/info/presenter-information/final-information-paper-authors.md
@@ -10,25 +10,25 @@ This page provides authors of accepted papers with important information for the
 
 ## CAMERA READY PAPERS SUBMISSION
 
-**DEADLINE: August 1.** Submit final papers and supplemental materials via the [Precision Conference System](https://new.precisionconference.com/~vgtc/).
+**DEADLINE: September 7.** Submit final papers and supplemental materials via the [Precision Conference System](https://new.precisionconference.com/~vgtc/).
 
-Camera-ready papers may not exceed 11 pages (9 pages of main text and 2 pages of references). The [website](http://junctionpublishing.org/vgtc/Track/vis-menu.html) has complete information regarding formatting requirements of your final revised PDF, copyright form, and optional videos. We do not need hardcopy. Please note in particular the suggestions for ensuring that the images in your PDF document are stored at sufficiently high resolution instead of using the default lossy compression settings.
+Camera-ready papers may not exceed 11 pages (9 pages of main text and 2 pages of references). The [website](http://vgtc.org/publications/journal) has complete information regarding formatting requirements of your final revised PDF, copyright form, and optional videos. We do not need hardcopy. Please note in particular the suggestions for ensuring that the images in your PDF document are stored at sufficiently high resolution instead of using the default lossy compression settings.
 
 Please check the second round reviewer comments (if any) and incorporate their suggestions. Note: there will not be further detailed proof-reading of your submission, so PLEASE read through your manuscript very carefully to fix any remaining grammar and spelling problems. If you are not a native English speaker, we very strongly recommend you recruit one to do the final careful pass on your paper. Also note the strict page limits. The 10th and 11th pages, if used, may not contain anything other than references (we will be strict on this). Finally, your paper should not be anonymized in the final version. The paper must include authors and affiliations. Note that if you have been anonymizing then you may find you have to trim your text to fit into the page limits once authors and affiliations are added.
 
 IMPORTANT: Please make sure the final submission data in PCS is identical to the final PDF (e.g. title, author names and last names, affiliations, author order, emails.) You might need to correct the information in your PCS login in order to update the author information. You can do this by logging into your PCS account > my account > Change my contact information.
 
-You can include a video of your work on the conference USB stick. TVCG requires that supplemental material is also peer-reviewed, hence, this is only allowed if you have already submitted a video and if the reviewers have found it acceptable. Videos are usually up to 5 minutes in length, and you may also include other supplemental material such as additional images or source code. The website above includes information on how to do so.
+You can submit a video of your work for inclusion in the digital archive. TVCG requires that supplemental material is also peer-reviewed, hence, this is only allowed if you have already submitted a video and if the reviewers have found it acceptable. Videos are usually up to 5 minutes in length, and you may also include other supplemental material such as additional images or source code. The website above includes information on how to do so.
 
 At least one author per accepted paper must register to present the work. Also, an author from each paper will present a short preview in a prior session.
 
 ## VIDEO PREVIEW SUBMISSION
 
-It is **mandatory** for authors of all VIS papers to submit a [25-sec Video Preview](http://ieeevis.org/year/2019/info/presenter-information/fast-forward-and-video-previews) by August 15.
+It is **mandatory** for authors of all VIS papers to submit a [25-sec Video Preview](http://ieeevis.org/year/2020/info/presenter-information/fast-forward-and-video-previews) by September 7.
 
 ## COMMON EDITING MISTAKES AND NOTES FROM TVCG
 
-Under no circumstances will updates be accepted after 11.59 PM on August 1. We have allowed for exceptions in the past but we will be strict this year.  
+Under no circumstances will updates be accepted after 11.59 PM on September 7. We have allowed for exceptions in the past but we will be strict this year.  
 
 Common editting issues: 
 * Use the correct JOURNAL style template (http://vgtc.org/publications/journal)


### PR DESCRIPTION
Update deadlines.
Update link to VGTC formatting instructions.
Update links to 2020 site (note: the video-preview link is currently broken).