### PR TITLE
Shorten navigation and sidebar titles for virtual event guidance page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -119,7 +119,7 @@ menu:
                   - text: "Recording your Talk"
                     url: "/year/2020/info/presenter-information/talk-recording-guide"
                     is_new: true
-                  - text: "Virtual Guidance for Colocated Events, Tutorials, and Workshops"
+                  - text: "Guidance for Virtual Events"
                     url: "/year/2020/info/presenter-information/guidance-for-colocated-events"
                     is_new: true
 

--- a/_data/sidebars/call-for-participation.yml
+++ b/_data/sidebars/call-for-participation.yml
@@ -31,5 +31,5 @@
     #   url: "/year/2020/info/presenter-information/fast-forward-and-video-previews"
     - text: "Recording your Talk"
       url: "/year/2020/info/presenter-information/talk-recording-guide"
-    - text: "Virtual Guidance for Colocated Events, Tutorials, and Workshops"
+    - text: "Guidance for Virtual Events"
       url: "/year/2020/info/presenter-information/guidance-for-colocated-events"


### PR DESCRIPTION
This PR shortens the title used in the top navbar and sidebar to fix the layout issues