### PR TITLE
Correct vis short paper prefix

### DIFF
--- a/content/info/presenter-information/talk-recording-guide.md
+++ b/content/info/presenter-information/talk-recording-guide.md
@@ -98,11 +98,9 @@ If you create the captions using a different software package, subtitles in the 
 | **Info Vis**                   | f-info                |
 | **SciVis**                     | f-scivis              |
 
-| **VIS Short Papers Tracks**     | **Short Name Prefix** |
-|---------------------------------|-----------------------|
-| **VAST**                        | s-vast                |
-| **Info Vis**                    | s-info                |
-| **SciVis**                      | s-scivis              |
+| **VIS Short Papers**                      | **Short Name Prefix** |
+|-------------------------------------------|-----------------------|
+| **VAST, Info Vis, SciVis** (single track) | s-short               |
 
 | **Colocated Events**                      | **Short Name Prefix** |
 |-------------------------------------------|-----------------------|


### PR DESCRIPTION
This PR fixes an error I had in the table where I had broken the VIS short papers down by VAST/InfoVis/SciVis, however there's only a single track for short papers. I've updated the short name prefix assigned in the table to indicate this so it's not confusing to authors