### PR TITLE
Fix naming convention of colocated event to associated event

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -120,7 +120,7 @@ menu:
                     #url: "/year/2020/info/presenter-information/talk-recording-guide"
                     #is_new: true
                   - text: "Guidance for Virtual Events (coming soon)"
-                    #url: "/year/2020/info/presenter-information/guidance-for-colocated-events"
+                    #url: "/year/2020/info/presenter-information/guidance-for-associated-events"
                     #is_new: true
 
       - subsections:

--- a/_data/sidebars/call-for-participation.yml
+++ b/_data/sidebars/call-for-participation.yml
@@ -32,4 +32,4 @@
     #- text: "Recording your Talk"
     #  url: "/year/2020/info/presenter-information/talk-recording-guide"
     #- text: "Guidance for Virtual Events"
-    #  url: "/year/2020/info/presenter-information/guidance-for-colocated-events"
+    #  url: "/year/2020/info/presenter-information/guidance-for-associated-events"

--- a/content/info/presenter-information/guidance-for-associated-events.md
+++ b/content/info/presenter-information/guidance-for-associated-events.md
@@ -1,8 +1,8 @@
 ---
-title: Technical Guidance for Colocated Events, Tutorials, and Workshops
+title: Technical Guidance for Associated Events, Tutorials, and Workshops
 layout: page
 sidebar: call-for-participation
-permalink: /info/presenter-information/guidance-for-colocated-events
+permalink: /info/presenter-information/guidance-for-associated-events
 active_nav: "Contribute"
 contact: tech@ieeevis.org
 ---
@@ -86,7 +86,7 @@ following the [VIS talk recording guidelines](/year/2020/info/presenter-informat
 
 Each video provided must be named following a `<shortname>_<uniqueidentifier>.mp4` convention.
 The short name is assigned to your event by the Tech Committee to help us organize your event's content,
-and can be found [here for your event](/year/2020/info/presenter-information/talk-recording-guide#conference-track-and-colocated-event-short-name-prefixes).
+and can be found [here for your event](/year/2020/info/presenter-information/talk-recording-guide#conference-track-and-associated-event-short-name-prefixes).
 The unique identifier is used to uniquely associate a video with a Time Slot during your event
 in which it should be played. While the choice of this is up to the organizers of each event,
 it must be unique! Good options are: a number corresponding to the time slot, paper submission ID (if applicable),
@@ -96,9 +96,9 @@ talk title (if unique during the event).
 
 The virtual VIS conference webpage will be created using [Mini-Conf](https://github.com/Mini-Conf/Mini-Conf),
 and managed by the web committee (web@ieeevis.org). If you would like, the Mini-Conf webpage can provide
-a virtual conference presence for your colocated event as well, e.g., embed each
+a virtual conference presence for your associated event as well, e.g., embed each
 session's Youtube stream and chat channels, PDF links, calendar information, etc.
-Please let the web and tech committees know if you would like your colocated
+Please let the web and tech committees know if you would like your associated
 event to be hosted on the VIS conference webpage as well, or would prefer to receive the Youtube
 and chat information to provide this information separately through your event's webpage.
 It is also possible to do both, if you would like to include links to each session's Youtube stream on your

--- a/content/info/presenter-information/talk-recording-guide.md
+++ b/content/info/presenter-information/talk-recording-guide.md
@@ -8,10 +8,10 @@ contact: tech@ieeevis.org
 ---
 
 Please **read the following instructions carefully** for guidelines
-on preparing your video presentation for VIS 2020, or a VIS 2020 co-located event.
-If you’re presenting at VIS 2020, your talk is due with your camera ready submission
-on **September 7, 2020**. Due dates for co-located events may vary, please check with
-your co-located event.
+on preparing your video presentation for VIS 2020, or a VIS 2020 associated event.
+If you're presenting a VIS full or short paper your talk is due with your camera ready submission
+on **September 7, 2020**. Due dates for associated events may vary, please check with
+your associated event for information.
 
 Your talk submission consists of two pieces:
 
@@ -28,30 +28,20 @@ Your presentation must be in the following format:
 - 1920x1080 resolution at 30FPS
 - MPEG-4 using H.264 encoding (file extension is .mp4)
 - VIS full & short papers: the maximum size for your video is 500MB.
-  Co-located event talk sizes and lengths may vary, please see your co-located event for details
+  Associated event talk sizes and lengths may vary, please see your associated event for details
 - To encode/re-encode your video in the right format, you can use the free software [Handbrake](https://handbrake.fr/)
 - To check that your video is in the right format, you can use the free software [MediaInfo](https://mediaarea.net/en/MediaInfo)
 
 
-<style>
-td.header {
-    background-color: #fde5cc;
-}
-td.left {
-    font-weight: bold;
-    vertical-align: top;
-}
-</style>
-
 ## File Naming Convention
 Your video file must be named following a `<shortname>_<uniqueidentifier>.mp4` convention.
 The prefix is assigned based on the track or event your video is included in.
-For the the short name prefix please find your event or track in the tables [below](#conference-track-and-colocated-event-short-name-prefixes).
+For the the short name prefix please find your event or track in the tables [below](#conference-track-and-associated-event-short-name-prefixes).
 <!--https://docs.google.com/spreadsheets/d/1unVDXq4kqj0iZ_2d_TYU8a61NG65bg_dX6IU2jdOUJY/edit?usp=sharing-->
 Your talk’s unique identifier is:
 
 - VIS Papers: Your submission ID from PCS is your unique identifier
-- Colocated Events: Your event organizers will send information about the unique identifier
+- Associated Events: Your event organizers will send information about the unique identifier
 
 
 ## Recording Your Talk
@@ -90,7 +80,7 @@ subtitles to play during your video. During the conference your video will be pl
 If you create the captions using a different software package, subtitles in the SRT format are also acceptable.
 
 
-## Conference Track and Colocated Event Short Name Prefixes
+## Conference Track and Associated Event Short Name Prefixes
 
 | **VIS Full Papers Tracks**     | **Short Name Prefix** |
 |--------------------------------|-----------------------|
@@ -102,7 +92,7 @@ If you create the captions using a different software package, subtitles in the 
 |-------------------------------------------|-----------------------|
 | **VAST, Info Vis, SciVis** (single track) | s-short               |
 
-| **Colocated Events**                      | **Short Name Prefix** |
+| **Associated Events**                     | **Short Name Prefix** |
 |-------------------------------------------|-----------------------|
 | **VIS Arts Program**                      | a-arts                |
 | **VisInPractice**                         | a-visinpractice       |


### PR DESCRIPTION
This PR corrects a mistake I noticed in referring to "Associated Events" as "Colocated Events", which doesn't match the rest of the VIS page or terminology. This PR corrects that to "Associated Events".

I've also clarified the due date for VIS full/short papers vs. associated events.