### PR TITLE
presenting virtually guide

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -121,6 +121,9 @@ menu:
                   - text: "Guidance for Virtual Events"
                     url: "/year/2020/info/presenter-information/guidance-for-associated-events"
                     is_new: true
+                  - text: "Presenting at the Virtual Conference"
+                    url: "/year/2020/info/presenter-information/presenting-virtually"
+                    is_new: true
 
       - subsections:
           - heading: "Get Involved"

--- a/_data/sidebars/call-for-participation.yml
+++ b/_data/sidebars/call-for-participation.yml
@@ -38,3 +38,6 @@
       url: "/year/2020/info/presenter-information/talk-recording-guide"  
     - text: "Guidance for Virtual Events"
       url: "/year/2020/info/presenter-information/guidance-for-associated-events"
+    - text: "Presenting at the Virtual Conference"
+      url: "/year/2020/info/presenter-information/presenting-virtually"
+

--- a/content/info/presenter-information/presenting-virtually.md
+++ b/content/info/presenter-information/presenting-virtually.md
@@ -1,0 +1,91 @@
+---
+title: Presenting at the Virtual Conference
+layout: page
+sidebar: call-for-participation
+permalink: /info/presenter-information/presenting-virtually
+active_nav: "Contribute"
+contact: tech@ieeevis.org
+---
+
+# Before Your Session
+
+One or two days before your session you will receive an automated email
+from our scheduling system containing information about the session. This
+email will include the schedule, general information about how the sessions
+will work, and the Zoom, Youtube and Discord links.
+You will receive one such email for each session where you are a presenter,
+chair, or organizer.
+In each Zoom meeting there will be a technician managing the stream
+and assisting with technicial issues during the session.
+
+# Joining Your Session's Zoom Meeting
+
+The Zoom meeting will begin 15 minutes before
+the session starts to allow the contributors, chair, and technician to set up
+and test everyone's audio and video set up. Make sure you are in a well-lit
+and quiet room, and have your laptop plugged in.
+The Zoom meeting information will be included in the automated
+session information email.
+**Please make sure your Zoom is updated to the latest version.**
+After the audio/video check the technician will communicate with
+you over Zoom's text chat, so have this open in the pop-out view mode.
+
+After the A/V setup check you should disable your video unless you are
+preparing to speak or speaking on the stream.
+
+# During Your Session
+
+If your session contains playback of pre-recorded videos
+(e.g., paper presentations), the technician will play these back directly to Youtube.
+The videos will also be screen-shared back to Zoom so you can follow the session
+without watching YouTube. Note that the quality of screen sharing on Zoom is lower
+than the quality that will be seen on Youtube.
+
+## Do Not Watch Yourself on Youtube
+
+Even with the ultra low latency stream
+setting there are about 5 seconds of delay between the stream and Youtube. If you
+are watching Youtube for feedback on when you are live or what is playing
+on the stream, the delay will be disorienting and you will be late. When the technician's
+countdown to going live for Q&A or introductions ends, **you are live!**
+Having the Youtube stream playing in the background can also result in audio
+feedback on the stream when you are talking.
+
+## Live Q&A
+
+About one minute before the presentation ends the technician
+will stop screen-sharing to set up for the Q&A portion. At this time you
+should turn your video on.
+When your presentation video has ended the technician will switch the
+stream to display the Zoom meeting to allow live responses to questions
+from attendees.
+Questions will be asked via Youtube and Discord chat,
+the technician and chair will monitor these for questions and relay them to
+the presenters over Zoom's text chat.
+The Youtube and Discord chats will be synchronized, so only
+one needs to be monitored. We recommend monitoring the Discord chat, which will
+provide a richer experience and is where you can continue the conversion
+after the session ends.
+
+## The End of Your Session
+There is a **hard cut-off** 10 minutes after
+the session is scheduled to end to allow time to set up the next session,
+so please keep to the session schedule.
+Additional discussion after the session can be continued on Discord.
+
+# Example Session Tutorials
+Please watch the example session tutorials below to see what to expect as
+a presenter in the virtual conference.
+
+## Recorded Talk with Live Q&A
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/m-2eoQGoxFo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Live Presentation over Zoom
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NSdQZKnadnw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Live Panel over Zoom 
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Qg01LslV2xI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+


### PR DESCRIPTION
This adds a guide on presenting virtually with the same text that will be emailed to participants when they get the day-before session info, along with links to our example tutorial sessions. I've also linked this in top nav under "Contribute > Info for Contributors" and the sidebar under "Participating Virtually"