### PR TITLE
Add VisInPractice page to IEEE VIS 2021

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -229,8 +229,7 @@ menu:
                 is_external: true
               - text: "VisInPractice"
                 description: "Invited talks by visualization practitioners"
-                url: "https://visinpractice.github.io/"
-                is_external: true
+                url: "/year/2021/info/visinpractice"
               - text: "LDAV Symposium"
                 description: "Big Data Analysis and Visualization"
                 url: "https://ldav.org/"

--- a/content/info/call-participation/application-spotlights.md
+++ b/content/info/call-participation/application-spotlights.md
@@ -8,7 +8,7 @@ contact: spotlights@ieeevis.org
 ---
 
 # Application Spotlights at IEEE VIS
-There is a clear need to promote application-focused work in the VIS community. This is both due to the recognized need to engage real-world decision makers and to the growing awareness of the value of application work for generating basic research questions. Since 2019, we created a new format to help address this need: Application Spotlights. It is one of several components - including the VAST Challenge, the SciVis Contest and the VisInPractice program - which aim at bridging the gap between fundamental research and practical applications.
+There is a clear need to promote application-focused work in the VIS community. This is both due to the recognized need to engage real-world decision makers and to the growing awareness of the value of application work for generating basic research questions. Since 2019, we created a new format to help address this need: Application Spotlights. It is one of several components - including the VAST Challenge, the SciVis Contest and the [VisInPractice program](/year/2021/info/visinpractice) - which aim at bridging the gap between fundamental research and practical applications.
 
 
 ## What is an Application Spotlight?
@@ -44,7 +44,7 @@ Feel free to contact us at spotlights@ieeevis.org if you have any questions conc
 | May 10, 2021 | Notification |
 | May 28, 2021 | Final Submissions due |
 | t.b.d. | Announcement of Spotlights on ieeevis.org |
-      
+
 All deadlines are at **5:00pm Pacific Time (PDT)**.
 
 ## Chairs

--- a/content/info/visinpractice/visinpractice.md
+++ b/content/info/visinpractice/visinpractice.md
@@ -1,0 +1,54 @@
+---
+title: VisInPractice
+layout: page
+permalink: /info/visinpractice
+contact: vip@ieeevis.org
+---
+
+The **VisInPractice** associated event at **[IEEE VIS 2021](http://ieeevis.org/year/2021/welcome)** will feature invited talks by visualization practitioners during the week of **October 24-29, 2021**, held virtually.
+
+In the meantime, check out what happened at [VisInPractice 2020](https://visinpractice.github.io/assets/vip2020/index.html).
+
+The **VisInPractice** program is an opportunity for visualization practitioners and researchers to meet and share experiences, insights, and ideas in applying data visualization and visual analytics to real use cases. Our goal is to acknowledge successful transfers of visualization research into applications as well as current visualization practices in industry.
+
+## Suggest Visualization Practitioner Speakers
+
+Are you a visualization practitioner and want to speak about your work to the IEEE VIS community? Or do you know someone who would be a great speaker? We are now [accepting suggestions for speakers](mailto:vip@ieeevis.org), as well as practitioners who have never (or infrequently) attended the IEEE VIS conference.
+
+- - -
+
+# Virtual Program: Monday, October 25, 2021
+
+The entire VisInPractice program is dedicated to everyone interested in the **practical aspects of data visualization and visual analytics**. The focus will be on how to solve real use cases rather than discussing them from an academic perspective. The program targets both newcomers to visualization and visual analysis as well as returning members of the community seeking to learn about new tools and practices.
+
+
+## At-a-Glance Schedule
+
+**Session 1**: panel
+
+_(morning coffee break)_
+
+**Session 2**: panel
+
+_(lunch break)_
+
+**Session 3**: panel
+
+_(afternoon coffee break)_
+
+**Session 4**: capstone + panel
+
+- - -
+
+# The VisInPractice Team
+
+**Email:** [vip@ieeevis.org](mailto:vip@ieeevis.org)
+
+**Twitter:** [@visinpractice](https://twitter.com/visinpractice)
+
+**Chairs:**
+
+* Matthew Brehmer, _Tableau Research_
+* Matt Larsen, _Lawrence Livermore National Laboratory_
+* Zhicheng (Leo) Liu, _University of Maryland_
+* Sean McKenna, _Lucid Software_


### PR DESCRIPTION
Ported over content from the current VisInPractice site onto this page. We can fix the previous years' links and add a redirect once this is out! :) Thanks!

Image preview of the new page created:

![Screenshot from 2021-05-09 12-33-53](https://user-images.githubusercontent.com/1406149/117583386-15c14b80-b0c4-11eb-8e79-480359989a0a.png)
![Screenshot from 2021-05-09 12-34-04](https://user-images.githubusercontent.com/1406149/117583389-178b0f00-b0c4-11eb-9015-25734a6ce026.png)
![Screenshot from 2021-05-09 12-34-22](https://user-images.githubusercontent.com/1406149/117583392-19ed6900-b0c4-11eb-90b8-84bfeb3a7175.png)
