### PR TITLE
Update VisInPractice historical URLs off vis2020

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,7 +45,7 @@ menu:
                   # - text: "Conference Venue"
                   #   url: "#"
               #    - text: "Practitioner Guide"
-              #      url: "https://visinpractice.github.io/guide.html"
+              #      url: "https://visinpractice.github.io/assets/vip2020/"
               #      is_external: true
                   - text: "Full Program"
                     url: "/year/2020/info/week-at-a-glance"
@@ -228,7 +228,7 @@ menu:
                   is_external: true
                 - text: "VisInPractice"
                   description: "Invited talks by visualization practitioners"
-                  url: "https://visinpractice.github.io/"
+                  url: "https://visinpractice.github.io/assets/vip2020/"
                   is_external: true
                 - text: "VizSec Symposium"
                   description: "Visualization for Cyber Security"

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -42,7 +42,7 @@ layout: default
         title="Data Visualization Practitioners"
         description="Learn which sessions may be particularly interesting to visualization practitioners"
         button-text="VIS 2020 Practitioner Guide"
-        button-link="https://visinpractice.github.io/guide.html" %}
+        button-link="https://visinpractice.github.io/assets/vip2020/" %}
 </div-->
 
 {% include supporters.html


### PR DESCRIPTION
Updating historical links so we can set up redirects from the visinpractice site to our page on ieeevis.org.

There will be a few other PRs to other branches / master, where I have tried to update all of these links.

Thanks!