### PR TITLE
Update VisInPractice historical URLs off master

### DIFF
--- a/_includes/left_sidebar-2017.html
+++ b/_includes/left_sidebar-2017.html
@@ -12,19 +12,19 @@
 	<div class="welcome-leftbar">
 	  <div class="menu-title"><a href="/">Welcome</a></div>
 	</div>
-	      
-	
+
+
 	  <h3 class="menu-title">Registration and Travel</h3>
 	  <ol class="link-leftbar">
             <li> <a href="/year/2017/info/registration/hotel-information">Hotel Information</a></li>
-	    <li> <a href="/year/2017/info/registration/conference-registration">Conference Registration</a></li>		  
+	    <li> <a href="/year/2017/info/registration/conference-registration">Conference Registration</a></li>
 	    <li> <a href="/year/2017/info/registration/visa-assistance">Visa Assistance</a></li>
 	    <li><a href="/year/2017/info/registration/travel-directions">Travel Directions</a></li>
 	    <li><a href="/year/2017/info/things-to-do-in-downtown-phoenix.pdf">Things to do in Phoenix</a></li>
-            <li><a href="/year/2017/info/downtown-phoenix-restaurants.pdf">Downtown Phoenix Restaurants</a></li>	  
+            <li><a href="/year/2017/info/downtown-phoenix-restaurants.pdf">Downtown Phoenix Restaurants</a></li>
 	  </ol>
   	</div>
-	
+
 	<div>
 	<h3 class="menu-title">Participant Information</h3>
 	  <ol class="link-leftbar">
@@ -36,7 +36,7 @@
 	    <li><a href="/year/2017/info/registration/sharing">Room and Ride Sharing</a></li>
 	  </ol>
 	</div>
-	      
+
       <div>
     	<h3 class="menu-title">Full Program</h3>
 	  <ol class="link-leftbar">
@@ -45,39 +45,39 @@
       <!--      <li> <a href="/year/2017/info/week-at-a-glance">Week-at-a-Glance</a></li> -->
       <li> <a href="/year/2017/info/overview-amp-topics/practitioner-guide/pg">Practitioner Guide</a></li>
 	  </ol>
-      </div> 
-	      
+      </div>
+
 	<div id="sessions-leftbar" class=" blank">
-          <h3 class="menu-title">IEEE VIS Sessions</h3> 
+          <h3 class="menu-title">IEEE VIS Sessions</h3>
 	  <ol class="link-leftbar">
-	    <li><a href="/year/2017/keynote">Keynote Address</a></li>	  
-	    <li><a href="/year/2017/capstone">Capstone Address</a></li>	  
-	    <li><a href="/year/2017/info/papers">Accepted Papers List</a></li>	  
-	    <li><a href="/year/2017/info/overview-amp-topics/papers-sessions">Papers Sessions</a></li>	  
-	    <li><a href="/year/2017/info/posters">Posters</a></li>	  
-	    <li><a href="/year/2017/info/workshops">Workshops</a></li>	  
-	    <li><a href="/year/2017/info/tutorials">Tutorials</a></li>  	    
-	    <li><a href="/year/2017/info/panels">Panels</a></li>	  
-	    <li><a href="/year/2017/info/overview-amp-topics/doctoral-colloquium">Doctoral Colloquium</a></li>	  
+	    <li><a href="/year/2017/keynote">Keynote Address</a></li>
+	    <li><a href="/year/2017/capstone">Capstone Address</a></li>
+	    <li><a href="/year/2017/info/papers">Accepted Papers List</a></li>
+	    <li><a href="/year/2017/info/overview-amp-topics/papers-sessions">Papers Sessions</a></li>
+	    <li><a href="/year/2017/info/posters">Posters</a></li>
+	    <li><a href="/year/2017/info/workshops">Workshops</a></li>
+	    <li><a href="/year/2017/info/tutorials">Tutorials</a></li>
+	    <li><a href="/year/2017/info/panels">Panels</a></li>
+	    <li><a href="/year/2017/info/overview-amp-topics/doctoral-colloquium">Doctoral Colloquium</a></li>
 	    <li><a href="/year/2017/info/meetups">Meetups</a></li>
 	    <li><a href="https://vimeo.com/groups/480818">FF Videos</a></li>
-	    <li><a href="/year/2017/info/overview-amp-topics/scivis-contest">SciVis Contest</a></li>	  
-	    <li><a href="/year/2017/info/overview-amp-topics/vast-challenge-program">VAST Challenge</a></li>	  
-	    <li><a href="/year/2017/info/overview-amp-topics/vis-in-practice">VIS in Practice</a></li>	  
+	    <li><a href="/year/2017/info/overview-amp-topics/scivis-contest">SciVis Contest</a></li>
+	    <li><a href="/year/2017/info/overview-amp-topics/vast-challenge-program">VAST Challenge</a></li>
+	    <li><a href="/year/2017/info/overview-amp-topics/vis-in-practice">VIS in Practice</a></li>
 	  </ol>
 	</div>
-	      
+
 	<div id="awards-leftbar" class=" blank">
-          <h3 class="menu-title">Awards and Recognitions</h3> 
+          <h3 class="menu-title">Awards and Recognitions</h3>
 	  <ol class="link-leftbar">
-            <li><a href="/year/2017/info/awards/test-of-time-awards">Test of Time Awards</a></li>	
+            <li><a href="/year/2017/info/awards/test-of-time-awards">Test of Time Awards</a></li>
 	    <li><a href="/year/2017/info/awards/best-paper-awards">Best Paper Awards</a></li>
-            <li><a href="http://vgtc.org/content/visualization-technical-awards"> VGTC VIS Awards </a></li>	    
-		  <li><a href="/year/2017/info/awards/best-poster-awards">Best Poster Awards</a></li>	  
+            <li><a href="http://vgtc.org/content/visualization-technical-awards"> VGTC VIS Awards </a></li>
+		  <li><a href="/year/2017/info/awards/best-poster-awards">Best Poster Awards</a></li>
 	    <li><a href="/year/2017/info/awards/vast-challenge-awards">VAST Challenge Awards</a></li>
 	  </ol>
 	</div>
-	    
+
       <h3 class="menu-title">Associated Events</h3>
 	  <ol class="link-leftbar">
       <li><a href="http://ldav.org/">LDAV: Large Data Analysis and Visualization</a></li>
@@ -88,21 +88,21 @@
 	    <li><a href="http://sciviscontest-staging.ieeevis.org/">SciVis Contest</a></li>
       <li><a href="http://biovis.net/2017/ieeevis/">BioVis Challenges</a></li>
 	    <li><a href="http://visap.uic.edu/2017/callforentries.html">VIS Arts Program</a></li>
-	    <li><a href="http://www.visinpractice.rwth-aachen.de/index.html">VIP: Visualization in Practice</a></li>
+	    <li><a href="https://visinpractice.github.io/assets/vip2017/">VIP: Visualization in Practice</a></li>
 	    <li><a href="http://www.vislies.org/">VIS Lies</a></li>
-	    <li><a href="/year/2017/info/exhibition/viskids-event">VisKids</a></li> 
+	    <li><a href="/year/2017/info/exhibition/viskids-event">VisKids</a></li>
       <li><a href="http://gicentre.net/velo-club-de-vis/">Velo Club de VIS</a></li>
       <li><a href="http://vacommunity.org/ieeevpg/">Vis Pioneers Group</a></li>
 	  </ol>
 	</div>
 
-	    
+
 	<h3 class="menu-title">Student Volunteers</h3>
 	<ol class="link-leftbar">
 	 <li><a href="http://vissv.org">Information</a></li>
 	 <li><a href="/year/2017/info/overview-amp-topics/student-volunteer-directory">SV Directory</a></li>
 	</ol>
-	      	      	
+
 	<div id="cfp-leftbar" class="_blank">
 	  <h3 class="menu-title">Call for Participation</h3>
 	  <ol class="link-leftbar">
@@ -125,12 +125,12 @@
 	  </ol>
 	</div>
 	<div>
-		
+
 	<div id="supporters-leftbar">
 	  <h3 class="menu-title"><a href="/year/2017/info/exhibition/supporters-and-exhibition">Supporters and Exhibition</a></h3>
 	</div>
 	<div>
-	      
+
 	<div id="committee-leftbar">
 	  <h3 class="menu-title">Committees</h3>
 	  <ol class="link-leftbar">
@@ -156,7 +156,7 @@
 	    <li><a href="https://goo.gl/forms/ySXhhpatJWHZ3nvI2">Tutorials/Panels</a></li>
 	  </ol>
 	</div>
-	
+
 	<p></p>
 	<div id="archive-leftbar">
 	  <h3 class="menu-title">Previous Years</h3>

--- a/_includes/left_sidebar-2018.html
+++ b/_includes/left_sidebar-2018.html
@@ -5,7 +5,7 @@
 	<div class="welcome-leftbar">
 	  <div class="menu-title"><a href="/">Welcome</a></div>
 	</div>
-	    
+
 	 <div id="sessions-leftbar" class=" blank">
 	   <h3 class="menu-title">Registration and Travel</h3>
 	   <ol class="link-leftbar">
@@ -19,14 +19,14 @@
         <!--     <li><a href="/year/2017/info/downtown-phoenix-restaurants.pdf">Downtown Phoenix Restaurants</a></li>	   -->
 	   </ol>
   	</div>
-	      
+
 	<div id="sessions-leftbar" class=" blank">
         <h3 class="menu-title">IEEE VIS Program</h3>
-	  <ol class="link-leftbar"> 
+	  <ol class="link-leftbar">
 	<!--    <li><a href="/attachments/VIS2018_AAG.pdf">VIS2018 AT-A-GLANCE</a></li> -->
 	    <li><a href="/attachments/vis18-program.pdf">Full Program</a></li>
 			<li><a href="/attachments/vis18-badgeinsert.pdf">Pocket Program</a></li>
-			<li><a href="http://www.visinpractice.rwth-aachen.de/guide.html">Practitioner Guide</a></li>
+			<li><a href="https://visinpractice.github.io/assets/vip2018/guide.html">Practitioner Guide</a></li>
 			<li><a href="/year/2018/keynote">Keynote Address</a></li>
 	    <li><a href="/year/2018/capstone">Capstone Address</a></li>
 	    <li><a href="/year/2018/info/papers">Accepted Papers List</a></li>
@@ -34,8 +34,8 @@
 	    <li><a href="/year/2018/info/posters">Posters</a></li>
 	    <li><a href="/year/2018/info/workshops">Workshops</a></li>
         <!--     <li><a href="/year/2018/info/pre-approved-events-schedule">Pre-approved events schedule</a></li>  -->
-           <li><a href="/year/2018/info/tutorials">Tutorials</a></li>     
-	    <li><a href="/year/2018/info/panels">Panels</a></li>	  
+           <li><a href="/year/2018/info/tutorials">Tutorials</a></li>
+	    <li><a href="/year/2018/info/panels">Panels</a></li>
 	    <li><a href="/year/2018/info/doctoral-colloquium">Doctoral Colloquium</a></li>
 	     <li><a href="/year/2018/info/meetups">Meetups</a></li>
 	<!--     <li><a href="https://vimeo.com/groups/480818">FF Videos</a></li> -->
@@ -44,9 +44,9 @@
 	<!--     <li><a href="/year/2017/info/overview-amp-topics/vis-in-practice">VIS in Practice</a></li>	   -->
 	</ol>
 	</div>
-	          
 
-	
+
+
 	<div>
 	<h3 class="menu-title">Participant Information</h3>
 	<ol class="link-leftbar">
@@ -56,9 +56,9 @@
 	<li><a href="/year/2018/info/call-participation/community#vis-buddies">Vis Buddies</a></li>
 	<li><a href="/year/2018/info/call-participation/community#ajf">Job Fair</a></li>
 	<!--     <li><a href="/year/2017/info/registration/sharing">Room and Ride Sharing</a></li> -->
-	   </ol> 
-	 </div> 
-	      
+	   </ol>
+	 </div>
+
       <!-- <div> -->
       <!-- 	<h3 class="menu-title">Full Program</h3> -->
       <!-- 	  <ol class="link-leftbar"> -->
@@ -68,43 +68,42 @@
       <!-- <li> <a href="/year/2017/info/overview-amp-topics/practitioner-guide/pg">Practitioner Guide</a></li> -->
       <!-- 	  </ol> -->
       <!-- </div>  -->
-	      
+
       <div id="awards-leftbar" class=" blank">
         <h3 class="menu-title">Awards and Recognitions</h3>
       	<ol class="link-leftbar">
                  <li><a href="/year/2018/info/awards/test-of-time-awards">Test of Time Awards</a></li>
       		 <li><a href="/year/2018/info/awards/best-paper-awards">Best Paper Awards</a></li>
       <!--       <li><a href="http://vgtc.org/content/visualization-technical-awards"> VGTC VIS Awards </a></li>	     -->
-       	 <li><a href="/year/2018/info/awards/best-poster-awards">Best Poster Awards</a></li>	  
+       	 <li><a href="/year/2018/info/awards/best-poster-awards">Best Poster Awards</a></li>
       <!-- 	    <li><a href="/year/2018/info/awards/vast-challenge-awards">VAST Challenge Awards</a></li> -->
 		<li><a href="/year/2018/info/awards/best-scivis-contest">SciVis Contest Awards</a></li>
 		<li><a href="/year/2018/info/vgtc-vis-awards">VGTC VIS Awards</a></li>
 		<li><a href="/year/2018/info/awards/service-awards">Service Awards</a></li>
       	</ol>
       </div>
-	    
+
        <div>
        <h3 class="menu-title">Associated Events</h3>
        	  <ol class="link-leftbar">
            <li><a href="https://beliv-workshop.github.io/">Beliv</a></li>
            <li><a href="http://biovis.net/2018/ieeevis/">BioVis Challenges</a></li>
            <li><a href="http://ldav2018.org/">LDAV</a></li>
-           <li><a href="http://sciviscontest2018.org/">SciVis Contest</a></li> 	
+           <li><a href="http://sciviscontest2018.org/">SciVis Contest</a></li>
       <!-- <li><a href="http://www.visualanalyticshealthcare.org/">VAHC: Visual Analytics in Healthcare</a></li> -->
-           <li><a href="http://www.vacommunity.org/VAST+Challenge+2018">VAST Challenge</a></li> 
+           <li><a href="http://www.vacommunity.org/VAST+Challenge+2018">VAST Challenge</a></li>
 	   <li><a href="http://www.visualdatascience.org/2018/index.html">VDS: Vis in Data Science</a></li>
-           <li><a href="http://visap.net/">VIS Arts Program</a></li> 
-      	   <li><a href="http://www.visinpractice.rwth-aachen.de/">VisInPractice</a></li>
+           <li><a href="http://visap.net/">VIS Arts Program</a></li>
+      	   <li><a href="https://visinpractice.github.io/assets/vip2018/">VisInPractice</a></li>
 	   <li><a href="http://vizsec.org/vizsec2018/#cfp">VizSec</a></li>
-      <!-- 	    <li><a href="http://www.visinpractice.rwth-aachen.de/index.html">VIP: Visualization in Practice</a></li> -->
       <!-- 	    <li><a href="http://www.vislies.org/">VIS Lies</a></li> -->
       <!-- 	    <li><a href="/year/2017/info/exhibition/viskids-event">VisKids</a></li>  -->
            <li><a href="https://gicentre.net/velo-club-de-vis/">Velo Club de VIS</a></li>
            <li><a href="http://vacommunity.org/ieeevpg/">Vis Pioneers Group</a></li>
        	  </ol>
        	</div>
-	 
-	      
+
+
 	<div id="inclusion-leftbar" class="_blank">
 	  <h3 class="menu-title">Inclusion and Diversity</h3>
 	  <ol class="link-leftbar">
@@ -112,15 +111,15 @@
 		  <li><a href="/year/2018/info/inclusion-and-diversity/code-of-conduct">Code of Conduct</a></li>
 		  <li><a href="/year/2018/info/inclusion-and-diversity/viskids-event">VisKids</a></li>
 		  <li><a href="/year/2018/info/inclusion-and-diversity/diversity-scholarship">Inclusivity & Diversity Scholarship</a></li>
-		  
+
 	  </ol>
 	</div>
-	      
+
 	<div id="supporters-leftbar">
 	  <h3 class="menu-title"><a href="/year/2018/info/exhibition/supporters-and-exhibition">Supporters and Exhibition</a></h3>
 	</div>
 
-	      
+
        <div>
        <h3 class="menu-title">Co-located Events</h3>
 	  <ol class="link-leftbar">
@@ -129,30 +128,30 @@
 	  </ol>
 	</div>
 
-	<div>    
+	<div>
 	 <h3 class="menu-title">Student Volunteers</h3>
 	 <ol class="link-leftbar">
 	  <li><a href="http://vissv.org">Information</a></li>
-	  <li><a href="https://goo.gl/forms/O0O2Zfeq6MDcYcU83">SV Application</a></li>	 
-	  <li><a href="http://vissv.org/shirtcontest.html">T-Shirt Design Contest</a></li>	 
+	  <li><a href="https://goo.gl/forms/O0O2Zfeq6MDcYcU83">SV Application</a></li>
+	  <li><a href="http://vissv.org/shirtcontest.html">T-Shirt Design Contest</a></li>
 	<!--  <li><a href="/year/2017/info/overview-amp-topics/student-volunteer-directory">SV Directory</a></li> -->
-	  </ol>	      	      
-	 </div> 
-	      
-	      
-	      
-	 <div id="cfp-leftbar" class="_blank"> 
-	   <h3 class="menu-title">Call for Participation</h3> 
-	   <ol class="link-leftbar"> 
-	     <li><a href="/year/2018/info/important-dates">Important Dates</a></li> 
-	     <li><a href="/year/2018/info/call-participation/papers">Papers</a></li> 
-	     <li> 
-	       <a href="/year/2018/info/call-participation/vast-paper-types">VAST</a> &#183; 
-	       <a href="/year/2018/info/call-participation/infovis-paper-types">InfoVis</a> &#183; 
-	       <a href="/year/2018/info/call-participation/scivis-paper-types">SciVis</a></li> 
+	  </ol>
+	 </div>
+
+
+
+	 <div id="cfp-leftbar" class="_blank">
+	   <h3 class="menu-title">Call for Participation</h3>
+	   <ol class="link-leftbar">
+	     <li><a href="/year/2018/info/important-dates">Important Dates</a></li>
+	     <li><a href="/year/2018/info/call-participation/papers">Papers</a></li>
+	     <li>
+	       <a href="/year/2018/info/call-participation/vast-paper-types">VAST</a> &#183;
+	       <a href="/year/2018/info/call-participation/infovis-paper-types">InfoVis</a> &#183;
+	       <a href="/year/2018/info/call-participation/scivis-paper-types">SciVis</a></li>
 	     <li><a href="/year/2018/info/call-participation/partnerships">Partnerships: TVCG/CG&amp;A</a></li>
 	     <li><a href="/year/2018/info/call-participation/scivis-short-papers">SciVis short papers</a></li>
-	     <li><a href="/year/2018/info/call-participation/posters">Posters</a></li> 
+	     <li><a href="/year/2018/info/call-participation/posters">Posters</a></li>
 	     <li><a href="/year/2018/info/call-participation/tutorials">Tutorials</a></li>
 	     <li><a href="/year/2018/info/call-participation/workshops">Workshops</a></li>
 	     <li><a href="/year/2018/info/call-participation/panels">Panels</a></li>
@@ -163,14 +162,14 @@
 	     <li><a href="/year/2018/info/inclusion-and-diversity/viskids-child-care-grants">VisKids Childcare Grants</a></li>
 	     <li><a href="/year/2018/info/inclusion-and-diversity/diversity-scholarship">Inclusivity & Diversity Scholarship</a></li>
 	     <!-- <li><a href="http://vacommunity.org/ieeevpg/bestthesis/">VPG Doctoral Dissertation Contest</a></li>  -->
-	   </ol> 
-	 </div> 
-	            
-	      
-	<div id="committee-leftbar"> 
-	  <h3 class="menu-title">Committees</h3> 
-	  <ol class="link-leftbar"> 
-	    <li><a href="/year/2018/info/committees/conference-committee">VIS Conference Committee</a></li> 
+	   </ol>
+	 </div>
+
+
+	<div id="committee-leftbar">
+	  <h3 class="menu-title">Committees</h3>
+	  <ol class="link-leftbar">
+	    <li><a href="/year/2018/info/committees/conference-committee">VIS Conference Committee</a></li>
 	<li>Program Committees</li>
 	  <li><a href="/year/2018/info/committees/vast-program-committee">VAST</a> &#183;
 	      <a href="/year/2018/info/committees/infovis-program-committee">InfoVis</a> &#183;
@@ -188,13 +187,13 @@
 	  </ol>
 	</div>
 
-	 <div> 
-	   <h3 class="menu-title">Surveys</h3> 
-	   <ol class="link-leftbar"> 
-	     <li><a href="https://www.surveymonkey.com/r/ieeevis">Conference Survey</a></li> 
-	   </ol> 
-	 </div> 
-	
+	 <div>
+	   <h3 class="menu-title">Surveys</h3>
+	   <ol class="link-leftbar">
+	     <li><a href="https://www.surveymonkey.com/r/ieeevis">Conference Survey</a></li>
+	   </ol>
+	 </div>
+
 	<p></p>
 	<div id="archive-leftbar">
 	  <h3 class="menu-title">Previous Years</h3>

--- a/_includes/left_sidebar-2019-full.html
+++ b/_includes/left_sidebar-2019-full.html
@@ -5,7 +5,7 @@
 	<div class="welcome-leftbar">
 	  <div class="menu-title"><a href="/">Welcome</a></div>
 	</div>
-	
+
 	<!-- <div id="sessions-leftbar" class=" blank">
 	  <h3 class="menu-title">Registration and Travel</h3>
 	  <ol class="link-leftbar"> -->
@@ -16,14 +16,14 @@
 	    <!-- <li><a href="/year/2017/info/registration/travel-directions">Travel Directions</a></li> -->
 	  <!-- </ol>
   	</div> -->
-	
+
 	<!-- <div id="sessions-leftbar" class=" blank">
           <h3 class="menu-title">IEEE VIS Program</h3>
 	  <ol class="link-leftbar"> -->
 	    <!-- <li><a href="/attachments/VIS2018_AAG.pdf">VIS2018 AT-A-GLANCE</a></li> -->
 	    <!-- <li><a href="/attachments/vis18-program.pdf">Full Program</a></li> -->
 	    <!-- <li><a href="/attachments/vis18-badgeinsert.pdf">Pocket Program</a></li> -->
-	    <!-- <li><a href="http://www.visinpractice.rwth-aachen.de/guide.html">Practitioner Guide</a></li> -->
+	    <!-- <li><a href="https://visinpractice.github.io/assets/vip2018/guide.html">Practitioner Guide</a></li> -->
 	    <!-- <li><a href="/year/2018/keynote">Keynote Address</a></li> -->
 	    <!-- <li><a href="/year/2018/capstone">Capstone Address</a></li> -->
 	    <!-- <li><a href="/year/2018/info/papers">Accepted Papers List</a></li> -->
@@ -52,7 +52,7 @@
 	    <!-- <li><a href="/year/2017/info/registration/sharing">Room and Ride Sharing</a></li> -->
 	  <!-- </ol>
 	</div> -->
-	
+
 	<!-- <div> -->
 	  <!-- 	<h3 class="menu-title">Full Program</h3> -->
 	  <!-- 	  <ol class="link-leftbar"> -->
@@ -62,7 +62,7 @@
 	      <!-- <li> <a href="/year/2017/info/overview-amp-topics/practitioner-guide/pg">Practitioner Guide</a></li> -->
 	      <!-- 	  </ol> -->
 	  <!-- </div>  -->
-	
+
 	<!-- <div id="awards-leftbar" class=" blank">
           <h3 class="menu-title">Awards and Recognitions</h3>
       	  <ol class="link-leftbar"> -->
@@ -76,7 +76,7 @@
 	    <!-- <li><a href="/year/2018/info/awards/service-awards">Service Awards</a></li> -->
       	  <!-- </ol>
 	</div> -->
-	
+
 	<!-- <div>
 	  <h3 class="menu-title">Associated Events</h3>
        	  <ol class="link-leftbar"> -->
@@ -88,30 +88,30 @@
             <!-- <li><a href="http://www.vacommunity.org/VAST+Challenge+2018">VAST Challenge</a></li>  -->
 	    <!-- <li><a href="http://www.visualdatascience.org/2018/index.html">VDS: Vis in Data Science</a></li> -->
             <!-- <li><a href="http://visap.net/">VIS Arts Program</a></li>  -->
-      	    <!-- <li><a href="http://www.visinpractice.rwth-aachen.de/">VisInPractice</a></li> -->
+      	    <!-- <li><a href="https://visinpractice.github.io/assets/vip2019/">VisInPractice</a></li> -->
 	    <!-- <li><a href="http://vizsec.org/vizsec2018/#cfp">VizSec</a></li> -->
-	    <!-- <li><a href="http://www.visinpractice.rwth-aachen.de/index.html">VIP: Visualization in Practice</a></li> -->
+	    <!-- <li><a href="https://visinpractice.github.io/assets/vip2019/">VIP: Visualization in Practice</a></li> -->
 	    <!-- <li><a href="http://www.vislies.org/">VIS Lies</a></li> -->
 	    <!-- <li><a href="/year/2017/info/exhibition/viskids-event">VisKids</a></li>  -->
             <!-- <li><a href="https://gicentre.net/velo-club-de-vis/">Velo Club de VIS</a></li> -->
             <!-- <li><a href="http://vacommunity.org/ieeevpg/">Vis Pioneers Group</a></li> -->
        	  <!-- </ol>
        	</div> -->
-	
+
 	<div id="inclusion-leftbar" class="_blank">
 	  <h3 class="menu-title">Inclusion and Diversity</h3>
-	  <ol class="link-leftbar"> 
+	  <ol class="link-leftbar">
 	    <li><a href="/year/2019/info/inclusion-and-diversity/inclusivity">About</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/code-of-conduct">Code of Conduct</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/viskids-event">VisKids</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/diversity-scholarship">Inclusivity & Diversity Scholarship</a></li>
 	  </ol>
 	</div>
-	
+
 	<!-- <div id="supporters-leftbar"> -->
 	  <!-- <h3 class="menu-title"><a href="/year/2018/info/exhibition/supporters-and-exhibition">Supporters and Exhibition</a></h3> -->
 	<!-- </div> -->
-	
+
 	<!-- <div> -->
 	  <!--   <h3 class="menu-title">Co-located Events</h3> -->
 	  <!--   <ol class="link-leftbar"> -->
@@ -129,7 +129,7 @@
 	    <!-- <li><a href="/year/2017/info/overview-amp-topics/student-volunteer-directory">SV Directory</a></li> -->
 	  <!-- </ol>
 	</div> -->
-	
+
 	<div id="cfp-leftbar" class="_blank">
 	  <h3 class="menu-title">Call for Participation</h3>
 	  <ol class="link-leftbar">
@@ -154,7 +154,7 @@
 	    <!-- <li><a href="http://vacommunity.org/ieeevpg/bestthesis/">VPG Doctoral Dissertation Contest</a></li>  -->
 	  </ol>
 	</div>
-	
+
 	<!-- <div id="committee-leftbar">
 	  <h3 class="menu-title">Committees</h3>
 	  <ol class="link-leftbar"> -->
@@ -175,14 +175,14 @@
 	    <!-- <li><a href="http://vgtc.org/executive-committee">VGTC Executive Committee</a></li> -->
 	  <!-- </ol>
 	</div> -->
-	
+
 	<!-- <div>  -->
 	  <!--   <h3 class="menu-title">Surveys</h3>  -->
 	  <!--   <ol class="link-leftbar">  -->
 	    <!--     <li><a href="https://www.surveymonkey.com/r/ieeevis">Conference Survey</a></li>  -->
 	    <!--   </ol>  -->
 	  <!-- </div>  -->
-	
+
 	<p></p>
 	<div id="archive-leftbar">
 	  <h3 class="menu-title">Previous Years</h3>
@@ -228,7 +228,7 @@
 	<div class="menu-title">
 	  <a href="/year/2019/info/future-locations">Upcoming Years</a></div>
 	</div>
-      
+
       <div id="social-leftbar" class="_blank">
       	<h3 class="menu-title">Social media</h3>
       	<ol class="link-leftbar">

--- a/_includes/left_sidebar-2019.html
+++ b/_includes/left_sidebar-2019.html
@@ -5,19 +5,19 @@
 	<div class="welcome-leftbar">
 	  <div class="menu-title"><a href="/">Welcome</a></div>
 	</div>
-	
+
 	<div id="sessions-leftbar" class=" blank">
 	  <h3 class="menu-title">Registration and Travel</h3>
-	  <ol class="link-leftbar"> 
+	  <ol class="link-leftbar">
       	    <li><a href="/year/2019/info/registration/conference-registration">Conference Registration</a></li>
 	    <li><a href="/year/2019/info/registration/hotel-information">Hotel Information</a></li>
-	    <li><a href="/year/2019/info/registration/travel-visas">Visas &amp; Travel Authorizations</a></li>  
+	    <li><a href="/year/2019/info/registration/travel-visas">Visas &amp; Travel Authorizations</a></li>
 	    <!-- <li><a href="/year/2019/info/registration/travel-information">Travel Information</a></li> -->
 	    <!-- <li><a href="/year/2017/info/registration/visa-assistance">Visa Assistance</a></li> -->
 	    <!-- <li><a href="/year/2017/info/registration/travel-directions">Travel Directions</a></li> -->
 	  </ol>
   </div>
-	
+
 	<div id="sessions-leftbar" class=" blank">
           <h3 class="menu-title">IEEE VIS Program</h3>
 	  <ol class="link-leftbar">
@@ -25,17 +25,17 @@
 	    <!-- <li><a href="/attachments/vis18-program.pdf">Full Program</a></li> -->
 		<li><a href="/year/2019/info/week-at-a-glance">Full Program</a></li>
     <!--<li><a href="/attachments/VIS-2019-Pocket-Program.pdf">Current Program</a></li>-->
-	    <!-- <li><a href="http://www.visinpractice.rwth-aachen.de/guide.html">Practitioner Guide</a></li> -->
+	    <!-- <li><a href="https://visinpractice.github.io/assets/vip2018/guide.html">Practitioner Guide</a></li> -->
 	    <li><a href="/year/2019/keynote">Keynote Address</a></li>
 	    <li><a href="/year/2019/capstone">Capstone Address</a></li>
 		<!-- <li><a href="/year/2018/info/papers">Accepted Papers List</a></li> -->
 		<li><a href="/year/2019/info/papers-sessions">Papers Sessions</a></li>
 	    <li><a href="/year/2019/info/posters">Posters</a></li>
 	    <li><a href="/year/2019/info/workshops">Workshops</a></li>
-	    <li><a href="/year/2019/info/application-spotlights">Application Spotlights</a></li> 
+	    <li><a href="/year/2019/info/application-spotlights">Application Spotlights</a></li>
             <!-- <li><a href="/year/2018/info/pre-approved-events-schedule">Pre-approved events schedule</a></li>  -->
 		<li><a href="/year/2019/info/tutorials">Tutorials</a></li>
-	    <li><a href="/year/2019/info/panels">Panels</a></li>	  
+	    <li><a href="/year/2019/info/panels">Panels</a></li>
 	    <li><a href="/year/2019/info/doctoral-colloquium">Doctoral Colloquium</a></li>
 	    <li><a href="/year/2019/info/meetups">Meetups</a></li>
 	    <!-- <li><a href="https://vimeo.com/groups/480818">FF Videos</a></li> -->
@@ -55,7 +55,7 @@
 	    <!-- <li><a href="/year/2017/info/registration/sharing">Room and Ride Sharing</a></li> -->
 	  </ol>
 	</div>
-	
+
 	<!-- <div> -->
 	  <!-- 	<h3 class="menu-title">Full Program</h3> -->
 	  <!-- 	  <ol class="link-leftbar"> -->
@@ -65,7 +65,7 @@
 	      <!-- <li> <a href="/year/2017/info/overview-amp-topics/practitioner-guide/pg">Practitioner Guide</a></li> -->
 	      <!-- 	  </ol> -->
 	  <!-- </div>  -->
-	
+
 	<div id="awards-leftbar" class=" blank">
           <h3 class="menu-title">Awards and Recognitions</h3>
       	  <ol class="link-leftbar">
@@ -80,11 +80,11 @@
 	    <!-- <li><a href="/year/2018/info/awards/service-awards">Service Awards</a></li> -->
       <!-- </ol> -->
 	</div>
-	 
+
 	<div id="supporters-leftbar">
 	   <h3 class="menu-title"><a href="/year/2019/info/exhibition/supporters-and-exhibition">Supporters and Exhibition</a></h3>
 	</div>
-	      
+
 	<div id="cfp-leftbar" class="_blank">
 	  <h3 class="menu-title">Call for Participation</h3>
 	  <ol class="link-leftbar">
@@ -109,15 +109,15 @@
 	    <!-- <li><a href="http://vacommunity.org/ieeevpg/bestthesis/">VPG Doctoral Dissertation Contest</a></li>  -->
 	  </ol>
 	</div>
-	      
+
 	<div id="newFor2019-leftbar" class="_blank">
 	  <h3 class="menu-title">New for 2019&excl;</h3>
 	  <ol class="link-leftbar">
-	    <li><a href="/year/2019/info/call-participation/application-spotlights-cfp">Application Spotlights</a></li> 
-	    <li><a href="/year/2019/info/open-practices/open-practices">Open Practices</a></li> 
+	    <li><a href="/year/2019/info/call-participation/application-spotlights-cfp">Application Spotlights</a></li>
+	    <li><a href="/year/2019/info/open-practices/open-practices">Open Practices</a></li>
 	  </ol>
 	</div>
-	
+
 	<div>
 	  <h3 class="menu-title">Associated Events</h3>
        	  <ol class="link-leftbar">
@@ -125,35 +125,35 @@
 	          <li><a href="http://www.visualdatascience.org/2019/index.html">VDS: Vis in Data Science</a></li>
 	          <li><a href="http://www.vis4dh.org/">VIS4DH: Vis for the Digital Humanities</a></li>
             <li><a href="http://ldav.org/">LDAV: Large Data Analysis & Vis</a></li>
-      	    <li><a href="https://visinpractice.github.io/">VisInPractice</a></li>
+      	    <li><a href="https://visinpractice.github.io/assets/vip2019/">VisInPractice</a></li>
 	          <li><a href="https://vizsec.org/vizsec2019/">VizSec</a></li>
             <li><a href="https://vast-challenge.github.io/2019">VAST Challenge</a></li>
-            <li><a href="http://biovis.net/2019/ieeevis/">BioVis Challenges</a></li> 
+            <li><a href="http://biovis.net/2019/ieeevis/">BioVis Challenges</a></li>
             <li><a href="https://press3.mcs.anl.gov/2019-scivis-contest/">SciVis Contest</a></li>
-            <li><a href="https://visap.net/">VIS Arts Program</a></li> 
+            <li><a href="https://visap.net/">VIS Arts Program</a></li>
             <li><a href="https://www.gicentre.net/velo-club-de-vis/">Velo Club de VIS</a></li>
             <li><a href="http://vacommunity.org/ieeevpg/">Vis Pioneers Group</a></li>
        	  </ol>
        	</div>
-	
+
 	<div id="equity-leftbar" class="_blank">
 	  <h3 class="menu-title">Equity, Inclusion, & Diversity</h3>
-	  <ol class="link-leftbar"> 
-	    <li><a href="/year/2019/info/inclusion-and-diversity/open-conference">IEEE Computer Society Open Conference Statement</a></li> 
+	  <ol class="link-leftbar">
+	    <li><a href="/year/2019/info/inclusion-and-diversity/open-conference">IEEE Computer Society Open Conference Statement</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/event-conduct-safety">IEEE Event Conduct and Safety Statement</a></li>
-	    <li><a href="/year/2019/info/inclusion-and-diversity/code-of-conduct">IEEE VIS Code of Conduct</a></li>      
+	    <li><a href="/year/2019/info/inclusion-and-diversity/code-of-conduct">IEEE VIS Code of Conduct</a></li>
 	  </ol>
 	</div>
-	      
+
 	<div id="inclusion-leftbar" class="_blank">
 	  <h3 class="menu-title">Inclusivity Programs</h3>
-	  <ol class="link-leftbar"> 
+	  <ol class="link-leftbar">
 	    <li><a href="/year/2019/info/inclusion-and-diversity/inclusivity">About</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/viskids-event">VisKids</a></li>
 	    <li><a href="/year/2019/info/inclusion-and-diversity/diversity-scholarship">Inclusivity & Diversity Scholarship</a></li>
 	  </ol>
 	</div>
-	
+
 	<!-- <div> -->
 	  <!--   <h3 class="menu-title">Co-located Events</h3> -->
 	  <!--   <ol class="link-leftbar"> -->
@@ -165,12 +165,12 @@
 	<div id="sv-leftbar" class="_blank">
 	  <h3 class="menu-title">Student Volunteers</h3>
 	  <ol class="link-leftbar">
-	     <li><a href="http://vissv.org" target="_blank">Information</a></li> 
+	     <li><a href="http://vissv.org" target="_blank">Information</a></li>
              <li><a href="https://forms.gle/Qs8YPsP6hfJo2hGQ8" target="_blank">Apply</a></li>
 	     <li><a href="http://vissv.org/shirtcontest.html" target="_blank">T-Shirt Design Contest</a></li>
 	  </ol>
 	</div>
-	
+
 	<div id="committee-leftbar">
 	  <h3 class="menu-title">Committees</h3>
 	  <ol class="link-leftbar">
@@ -191,14 +191,14 @@
 	    <!-- <li><a href="http://vgtc.org/executive-committee">VGTC Executive Committee</a></li> -->
 	  </ol>
 	</div>
-	
+
 	<!-- <div>  -->
 	  <!--   <h3 class="menu-title">Surveys</h3>  -->
 	  <!--   <ol class="link-leftbar">  -->
 	    <!--     <li><a href="https://www.surveymonkey.com/r/ieeevis">Conference Survey</a></li>  -->
 	    <!--   </ol>  -->
 	  <!-- </div>  -->
-	
+
 	<p></p>
 	<div id="archive-leftbar">
 	  <h3 class="menu-title">Previous Years</h3>
@@ -245,7 +245,7 @@
 	<div class="menu-title">
 	  <a href="/year/2019/info/future-locations">Upcoming Years</a>
 	</div>
-      
+
       <div id="social-leftbar" class="_blank">
       	<h3 class="menu-title">Social media</h3>
       	<ol class="link-leftbar">

--- a/year/2017/info/overview-amp-topics/practitioner-guide/all-practitioners.md
+++ b/year/2017/info/overview-amp-topics/practitioner-guide/all-practitioners.md
@@ -19,10 +19,10 @@ The Visual Analytics Science and Technology (VAST) Challenge is an annual contes
 
 #### Monday
 
-* *Workshop* - **[Vis in Practice: Visualization Solutions in the Wild](http://www.visinpractice.rwth-aachen.de/workshop.html)** -
+* *Workshop* - **[Vis in Practice: Visualization Solutions in the Wild](https://visinpractice.github.io/assets/vip2017/workshop.html)** -
 Providing an opportunity for visualization practitioners and researchers to meet and share experiences, insights, and ideas in applying the latest visualization and visual analytics research to real world problems.
 
-* **[Discovery Jam](http://discoveryjam.com/)** - 
+* **[Discovery Jam](http://discoveryjam.com/)** -
 A live hackathon to scientific data discovery. You’ll leave the workshop with skills for communicating with scientists, approaches to cross-disciplinary collaboration, and new ideas to pursue further.
 
 * *Tutorial* - **[Large-scale Web-based Visual Analytics Made Easy](/year/2017/info/tutorials#Large-scale_Web-based_VA)**
@@ -33,7 +33,7 @@ A live hackathon to scientific data discovery. You’ll leave the workshop with 
 
 * *VIS Keynote Address* - **[Analytics Inspired Visualization: a Holistic In-situ Scientific Workflow at Extreme Scale](/year/2017/keynote)** - 10:50am-11:50am, Room: 301-CD
 
-* *Panel* - **[VIP - Increasing the Impact of Visualization Research](http://www.visinpractice.rwth-aachen.de/panel.html)** - 2:00pm-3:40pm, Room 101-ABC
+* *Panel* - **[VIP - Increasing the Impact of Visualization Research](https://visinpractice.github.io/assets/vip2017/panel.html)** - 2:00pm-3:40pm, Room 101-ABC
 
 * **Supporters Presentations** - 4:15pm-5:55pm, Room: 101-ABC
 
@@ -63,9 +63,9 @@ A live hackathon to scientific data discovery. You’ll leave the workshop with 
 
 
 -----
-*** 
+***
 
-> _Make sure to also check out the full program of the conference which can be found here: [http://ieeevis.org/](http://ieeevis.org/). 
+> _Make sure to also check out the full program of the conference which can be found here: [http://ieeevis.org/](http://ieeevis.org/).
 Depending on your specific domain and current data analysis challenges you will likely find more interesting events there!_
 
 

--- a/year/2017/info/panels.md
+++ b/year/2017/info/panels.md
@@ -5,39 +5,39 @@ permalink: /year/2017/info/panels
 contact: "panels@ieeevis.org"
 ---
 
-* [A Matter of Scale - Scale Matters](#scale-matters)
-* [Diversity in Visualization](#diversity-panel)
-* [How do Recent Machine Learning Advances Impact the Data Visualization Research Agenda?](#ml-agenda)
-* [Increasing the Impact of Visualization Research](#vip)
-* [Reflection on Reflection in Design Studies](#design-studies)
-* [Vision Science Meets Visualization](#vision-science)
+- [<a name="scale-matters"></a> A Matter of Scale - Scale Matters](#-a-matter-of-scale---scale-matters)
+- [<a name="diversity-panel"></a> Diversity in Visualization](#-diversity-in-visualization)
+- [<a name="ml-agenda"></a> How do Recent Machine Learning Advances Impact the Data Visualization Research Agenda?](#-how-do-recent-machine-learning-advances-impact-the-data-visualization-research-agenda)
+- [<a name="vip"></a> Increasing the Impact of Visualization Research](#-increasing-the-impact-of-visualization-research)
+- [<a name="design-studies"></a> Reflection on Reflection in Design Studies](#-reflection-on-reflection-in-design-studies)
+- [<a name="vision-science"></a> Vision Science Meets Visualization](#-vision-science-meets-visualization)
 
 
-## <a name="scale-matters"></a> [A Matter of Scale - Scale Matters](http://ieeevis.org) 
-Friday, OCTOBER 6  
-8:30AM-10:10AM  
-Location: 101-ABC   
+## <a name="scale-matters"></a> [A Matter of Scale - Scale Matters](http://ieeevis.org)
+Friday, OCTOBER 6
+8:30AM-10:10AM
+Location: 101-ABC
 
-Arthur Olson (Organizer), The Scripps Research Institute  
-Eduard Groeller (Organizer), TU Vienna  
-Alan M. MacEachren, Pennsylvania State University  
-Todd Richmond, USC Institute for Creative Technologies  
+Arthur Olson (Organizer), The Scripps Research Institute
+Eduard Groeller (Organizer), TU Vienna
+Alan M. MacEachren, Pennsylvania State University
+Todd Richmond, USC Institute for Creative Technologies
 Claudio Silva, New York University
 
 Contact: [groeller@cg.tuwien.ac.at](mailto:groeller@cg.tuwien.ac.at)
 
-Scale and scalability have been recurring topics in our field. Recent developments like smart data, machine learning, and advances in domains like biology, cartography, smart communities, and communication pose novel challenges to scalability and use of scale. Examples include support for scale-transparent visual computing, cross-scale visualization and interaction, massive multi-scale techniques, scale integration, cross-scale labeling and annotation, cross scales on structure and dynamics, and continuous scales. 
+Scale and scalability have been recurring topics in our field. Recent developments like smart data, machine learning, and advances in domains like biology, cartography, smart communities, and communication pose novel challenges to scalability and use of scale. Examples include support for scale-transparent visual computing, cross-scale visualization and interaction, massive multi-scale techniques, scale integration, cross-scale labeling and annotation, cross scales on structure and dynamics, and continuous scales.
 
-## <a name="diversity-panel"></a> [Diversity in Visualization](https://vimeo.com/240582265) 
-Thursday, OCTOBER 5  
-2:00PM-3:40PM 
+## <a name="diversity-panel"></a> [Diversity in Visualization](https://vimeo.com/240582265)
+Thursday, OCTOBER 5
+2:00PM-3:40PM
 Location: TBD
 
-Robert S. Laramee (Organizer), Swansea University  
+Robert S. Laramee (Organizer), Swansea University
 Rita Borgo, Kings College
-Vetria Byrd, Purdue Polytechnic Institute  
-Aviva Frank, State University of New York, Purchase  
-Kelly Gaither, University of Texas, Austin  
+Vetria Byrd, Purdue Polytechnic Institute
+Aviva Frank, State University of New York, Purchase
+Kelly Gaither, University of Texas, Austin
 Ronald Metoyer, University of Notre Dame
 Erica Yang, Science and Technology Facilities Council (STFC)
 
@@ -45,33 +45,33 @@ Contact: [r.s.laramee@swansea.ac.uk](mailto:r.s.laramee@swansea.ac.uk)
 
 This panel will address the lively topic of diversity in the fields of data visualization and visual analytics from gender, cultural, and technological points of view.
 
-## <a name="ml-agenda"></a> [How do Recent Machine Learning Advances Impact the Data Visualization Research Agenda?](https://vimeo.com/240317738) 
-Thursday, OCTOBER 5  
-10:30AM-12:10PM  
-Location: 207 Lecture Hall  
+## <a name="ml-agenda"></a> [How do Recent Machine Learning Advances Impact the Data Visualization Research Agenda?](https://vimeo.com/240317738)
+Thursday, OCTOBER 5
+10:30AM-12:10PM
+Location: 207 Lecture Hall
 
-Timo Ropinski (Organizer), Ulm University  
-Daniel Archambault, Swansea University  
-Min Chen, Oxford University  
-Ross Maciejewski, Arizona State University  
-Klaus Mueller, Stony Brook University  
-Alexandru Telea, University of Groningen  
+Timo Ropinski (Organizer), Ulm University
+Daniel Archambault, Swansea University
+Min Chen, Oxford University
+Ross Maciejewski, Arizona State University
+Klaus Mueller, Stony Brook University
+Alexandru Telea, University of Groningen
 Martin Wattenberg, Google
 
 Contact: [timo.ropinski@uni-ulm.de](mailto:timo.ropinski@uni-ulm.de)
 
 Nowadays, machine learning approaches have revolutionized many domains. As this pushes the human out of the loop, the human-in-the-loop paradigm might be endangered. Thus, we would like to investigate, which old visualization challenges are rendered obsolete, and which new visualization challenges arise from the recent advances in machine learning.
 
-## <a name="vip"></a> [Increasing the Impact of Visualization Research](http://www.visinpractice.rwth-aachen.de/panel.html)
-Tuesday, OCTOBER 3  
-2:00PM-3:40PM  
-Location: 101-ABC  
+## <a name="vip"></a> [Increasing the Impact of Visualization Research](https://visinpractice.github.io/assets/vip2017/)
+Tuesday, OCTOBER 3
+2:00PM-3:40PM
+Location: 101-ABC
 
-Steven M. Drucker, Microsoft Research  
-Adam Perer, IBM Research  
-Daniela Oelke, Siemens  
-Melanie Tory, Tableau Research  
-Krist Wongsuphasawat, Twitter  
+Steven M. Drucker, Microsoft Research
+Adam Perer, IBM Research
+Daniela Oelke, Siemens
+Melanie Tory, Tableau Research
+Krist Wongsuphasawat, Twitter
 Justing Talbot, Tableau Research
 
 Contact: [vip@ieeevis.org](mailto:vip@ieeevis.org)
@@ -80,17 +80,17 @@ The Vis in Practice panel is part of the IEEE VIS 2017 main program and provides
 
 
 ## <a name="design-studies"></a> [Reflection on Reflection in Design Studies](http://ieeevis.org)
-Thursday, OCTOBER 5  
-4:15PM-5:55PM  
-Location: 101-ABC  
+Thursday, OCTOBER 5
+4:15PM-5:55PM
+Location: 101-ABC
 
-Jason Dykes (Organizer), City University of London  
-Miriah Meyer (Organizer), University of Utah  
+Jason Dykes (Organizer), City University of London
+Miriah Meyer (Organizer), University of Utah
 Uta Hinrichs, St. Andrews University
-Nathalie Henry Riche, Microsoft Research  
-Remco Chang, Tufts University  
-Petra Isenberg, Inria  
-Heidi Lam, Tableau Research  
+Nathalie Henry Riche, Microsoft Research
+Remco Chang, Tufts University
+Petra Isenberg, Inria
+Heidi Lam, Tableau Research
 Tamara Munzner, University of British Columbia
 
 Contact: [J.Dykes@city.ac.uk](mailto:J.Dykes@city.ac.uk)
@@ -98,18 +98,18 @@ Contact: [J.Dykes@city.ac.uk](mailto:J.Dykes@city.ac.uk)
 Design study research methodologies emphasize the need for reflection to generate knowledge. We ask six researchers to reflect upon the role of reflection in design studies, as we try to share and develop good practice. Come along to participate in an interactive conversation around reflection, that underpins applied visualization research.
 
 ## <a name="vision-science"></a> [Vision Science Meets Visualization](https://vimeo.com/240736387)
-Wednesday, OCTOBER 4  
-2:00PM-3:40PM  
-Location: 101-ABC  
+Wednesday, OCTOBER 4
+2:00PM-3:40PM
+Location: 101-ABC
 
-Christine Nothelfer (Organizer), Northwestern University  
-Zoya Bylinskii (Organizer), Massachusetts Institute of Technology  
-Madison Elliott (Organizer), University of British Columbia  
-Cindy Xiong (Organizer), Northwestern University  
-Danielle Albers Szafir (Organizer), University of Colorado Boulder  
-Ronald Rensink, University of British Columbia  
-Steven Franconeri, Northwestern University  
-Karen Schloss, University of Wisconsin-Madison  
+Christine Nothelfer (Organizer), Northwestern University
+Zoya Bylinskii (Organizer), Massachusetts Institute of Technology
+Madison Elliott (Organizer), University of British Columbia
+Cindy Xiong (Organizer), Northwestern University
+Danielle Albers Szafir (Organizer), University of Colorado Boulder
+Ronald Rensink, University of British Columbia
+Steven Franconeri, Northwestern University
+Karen Schloss, University of Wisconsin-Madison
 Ruth Rosenholtz, Masachusetts Institute of Technology
 
 Contact: [Danielle.Szafir@Colorado.EDU](mailto:Danielle.Szafir@Colorado.EDU)

--- a/year/2017/info/workshops.md
+++ b/year/2017/info/workshops.md
@@ -5,29 +5,29 @@ permalink: /year/2017/info/workshops
 contact: "workshops@ieeevis.org"
 ---
 
-* [Immersive Analytics: Exploring Future Visualization and Interaction Technologies for Data Analytics](#immersive-analytics)
-* [Discovery Jam](#discovery-jam)
-* [DSIA: Data Systems for Interactive Analysis](#interactive-analysis)
-* [DECISIVe 2017: 2nd Workshop on Dealing with Cognitive Biases in Visualizations](#decisive)
-* [2nd Pedagogy of Data Visualization Workshop](#pedagogy)
-* [2nd Workshop on Visualization for the Digital Humanities](#vis-dh)
-* [Visual Analytics for Interpretable, User-Driven Deep Learning](#interpretable-dl)
-* [AVID: Advancing Visualization Inclusion and Diversity](#avid)
-* [Vis in Practice: Visualization Solutions in the Wild](#vip)
+- [<a name="immersive-analytics"></a> Immersive Analytics: Exploring Future Visualization and Interaction Technologies for Data Analytics](#-immersive-analytics-exploring-future-visualization-and-interaction-technologies-for-data-analytics)
+- [<a name="discovery-jam"></a> Discovery Jam](#-discovery-jam)
+- [<a name="interactive-analysis"></a> DSIA: Data Systems for Interactive Analysis](#-dsia-data-systems-for-interactive-analysis)
+- [<a name="decisive"></a> DECISIVe 2017: 2nd Workshop on Dealing with Cognitive Biases in Visualizations](#-decisive-2017-2nd-workshop-on-dealing-with-cognitive-biases-in-visualizations)
+- [<a name="pedagogy"></a> 2nd Pedagogy of Data Visualization Workshop](#-2nd-pedagogy-of-data-visualization-workshop)
+- [<a name="vis-dh"></a> 2nd Workshop on Visualization for the Digital Humanities](#-2nd-workshop-on-visualization-for-the-digital-humanities)
+- [<a name="interpretable-dl"></a> VADL 2017: Workshop on Visual Analytics for Deep Learning](#-vadl-2017-workshop-on-visual-analytics-for-deep-learning)
+- [<a name="avid"></a> AVID: Advancing Visualization Inclusion and Diversity](#-avid-advancing-visualization-inclusion-and-diversity)
+- [<a name="vip"></a> Vis in Practice - Visualization Solutions in the Wild](#-vis-in-practice---visualization-solutions-in-the-wild)
 
 
-## <a name="immersive-analytics"></a> [Immersive Analytics: Exploring Future Visualization and Interaction Technologies for Data Analytics](http://immersiveanalytics.net)  
-Sunday, October 1  
-8:30AM-5:55PM  
-102-ABC  
+## <a name="immersive-analytics"></a> [Immersive Analytics: Exploring Future Visualization and Interaction Technologies for Data Analytics](http://immersiveanalytics.net)
+Sunday, October 1
+8:30AM-5:55PM
+102-ABC
 
-Benjamin Bach, University of Edinburgh, UK / Harvard University, MA  
-Maxime Cordeil, Monash University, VIC  
-Tim Dwyer, Monash University, VIC  
-Bongshin Lee, Microsoft Research  
-Bahador Saket, Georgia Tech  
-Alex Endert, Georgia Tech  
-Christopher Collins, University of Ontario Institute of Technology  
+Benjamin Bach, University of Edinburgh, UK / Harvard University, MA
+Maxime Cordeil, Monash University, VIC
+Tim Dwyer, Monash University, VIC
+Bongshin Lee, Microsoft Research
+Bahador Saket, Georgia Tech
+Alex Endert, Georgia Tech
+Christopher Collins, University of Ontario Institute of Technology
 Sheelagh Carpendale, University of Calgary
 
 Contact: benj.bach@gmail.com
@@ -42,14 +42,14 @@ physical and tangible visualization, as well as interaction techniques.
 
 
 ## <a name="discovery-jam"></a> [Discovery Jam](http://discoveryjam.com)
-Monday, October 2  
-8:30AM-5:55PM  
-101-ABC  
+Monday, October 2
+8:30AM-5:55PM
+101-ABC
 
-David Rogers, Los Alamos National Lab  
-Dan Keefe, University of Minnesota  
-Francesca Samsel, University of Texas at Austin  
-Miriah Meyer, University of Utah  
+David Rogers, Los Alamos National Lab
+Dan Keefe, University of Minnesota
+Francesca Samsel, University of Texas at Austin
+Miriah Meyer, University of Utah
 Cecilia Aragon, University of Washington
 
 Contact: info@discoveryjam.com
@@ -62,20 +62,20 @@ Each DiscoveryJam scientist is matched with a small group of attendees. In
 the morning each group holds interactive discussions with their scientist
 about specific data and science problems. In the afternoon, each group hacks
 away on the scientist's data. We'll create sketches, prototypes, and sample
-visualizations, and then present them to the entire workshop. You'll leave 
-the workshop with skills for communicating with scientists, approaches to 
-cross-disciplinary collaboration, and research ideas to pursue further.  
+visualizations, and then present them to the entire workshop. You'll leave
+the workshop with skills for communicating with scientists, approaches to
+cross-disciplinary collaboration, and research ideas to pursue further.
 Bring your laptop and your favorite vis tools to dig into data with us.
 
 
-## <a name="interactive-analysis"></a> [DSIA: Data Systems for Interactive Analysis](http://www.interactive-analysis.org)  
-Monday, October 2  
-8:30AM-12:10PM  
-211-AB  
+## <a name="interactive-analysis"></a> [DSIA: Data Systems for Interactive Analysis](http://www.interactive-analysis.org)
+Monday, October 2
+8:30AM-12:10PM
+211-AB
 
-Remco Chang, Tufts University  
-Danyel Fisher, Microsoft Research  
-Jeffrey Heer, University of Washington  
+Remco Chang, Tufts University
+Danyel Fisher, Microsoft Research
+Jeffrey Heer, University of Washington
 Carlos Scheidegger, University of Arizona
 
 Contact: organizers@interactive-analysis.org
@@ -99,13 +99,13 @@ between these fields.
 
 
 ## <a name="decisive"></a> [DECISIVe 2017: 2nd Workshop on Dealing with Cognitive Biases in Visualizations](http://decisive-workshop.dbvis.de)
-Monday, October 2  
-8:30AM-12:10PM  
-105-ABC  
+Monday, October 2
+8:30AM-12:10PM
+105-ABC
 
-Geoffrey Ellis, University of Konstanz, Germany  
-Evanthia Dimara, Inria Saclay, France  
-Donald Kretz, Applied Research Associates, USA  
+Geoffrey Ellis, University of Konstanz, Germany
+Evanthia Dimara, Inria Saclay, France
+Donald Kretz, Applied Research Associates, USA
 Alex Endert, Georgia Tech, USA
 
 Contact: ellis@dbvis.inf.uni-konstanz.de
@@ -130,16 +130,16 @@ practical ways to reduce or overcome these potentially harmful effects,
 especially in adapting the tools developers design and build.
 
 
-## <a name="pedagogy"></a> [2nd Pedagogy of Data Visualization Workshop](http://vgl.cs.usfca.edu/pdvw/2017)  
-Sunday, October 1  
-2:00PM-5:55PM  
-106-ABC  
+## <a name="pedagogy"></a> [2nd Pedagogy of Data Visualization Workshop](http://vgl.cs.usfca.edu/pdvw/2017)
+Sunday, October 1
+2:00PM-5:55PM
+106-ABC
 
-Alark Joshi, University of San Francisco  
-Eytan Adar, University of Michigan  
-Enrico Bertini, New York University  
-Sophie Engle, University of San Francisco  
-Marti Hearst, University of California Berkeley  
+Alark Joshi, University of San Francisco
+Eytan Adar, University of Michigan
+Enrico Bertini, New York University
+Sophie Engle, University of San Francisco
+Marti Hearst, University of California Berkeley
 Daniel Keefe, University of Minnesota
 
 Contact: apjoshi@usfca.edu
@@ -155,16 +155,16 @@ classes, teaching at a liberal arts college, teaching a professional masters'
 course, and so on.
 
 
-## <a name="vis-dh"></a> [2nd Workshop on Visualization for the Digital Humanities](http://vis4dh.dbvis.de)  
-Monday, October 2  
-2:00PM-5:55PM  
-105-ABC  
+## <a name="vis-dh"></a> [2nd Workshop on Visualization for the Digital Humanities](http://vis4dh.dbvis.de)
+Monday, October 2
+2:00PM-5:55PM
+105-ABC
 
-Stefan Janicke, Leipzig University, Germany  
-Christopher Collins, University of Ontario Institute of Technology, Canada  
-Michael Correll, University of Washington, USA  
-Mennatallah El-Assady, University of Konstanz, Germany  
-Daniel Keim, University of Konstanz, Germany  
+Stefan Janicke, Leipzig University, Germany
+Christopher Collins, University of Ontario Institute of Technology, Canada
+Michael Correll, University of Washington, USA
+Mennatallah El-Assady, University of Konstanz, Germany
+Daniel Keim, University of Konstanz, Germany
 David Wrisley, New York University Abu Dhabi, UAE
 
 Contact: stjaenicke@informatik.uni-leipzig.de
@@ -178,14 +178,14 @@ digital humanities researchers, and (3) to establish future collaborations
 between visualization and digital humanities scholars.
 
 
-## <a name="interpretable-dl"></a> [VADL 2017: Workshop on Visual Analytics for Deep Learning](https://vadl2017.github.io)  
-Monday, October 2  
-2:00PM-5:55PM  
-211-AB  
+## <a name="interpretable-dl"></a> [VADL 2017: Workshop on Visual Analytics for Deep Learning](https://vadl2017.github.io)
+Monday, October 2
+2:00PM-5:55PM
+211-AB
 
-Jaegul Choo, Korea University  
-Shixia Liu, Tsinghua University  
-Jason Yosinski, Uber AI Labs  
+Jaegul Choo, Korea University
+Shixia Liu, Tsinghua University
+Jason Yosinski, Uber AI Labs
 Deokgun Park, University of Maryland, College Park
 
 Contact: jchoo@korea.ac.kr
@@ -199,12 +199,12 @@ opportunity to discuss and explore ways to harmonize the power of automated
 techniques and exploratory nature of interactive visualization.
 
 
-## <a name="avid"></a> [AVID: Advancing Visualization Inclusion and Diversity](https://www.avid-vis.org)  
-Sunday, October 1  
-8:30AM-12:10PM  
-106-ABC  
+## <a name="avid"></a> [AVID: Advancing Visualization Inclusion and Diversity](https://www.avid-vis.org)
+Sunday, October 1
+8:30AM-12:10PM
+106-ABC
 
-Penny Rheingans, University of Maryland, Baltimore County  
+Penny Rheingans, University of Maryland, Baltimore County
 Kelly Gaither, University of Texas
 
 Contact: rheingan@umbc.edu
@@ -227,14 +227,14 @@ opportunities in visualization, a greater understanding of challenges and
 strategies, and a wider network of those sharing their goals.
 
 
-## <a name="vip"></a> [Vis in Practice - Visualization Solutions in the Wild](http://www.visinpractice.rwth-aachen.de)  
-Monday, October 2  
-2:00PM-5:55PM  
-207 Lecture Hall  
+## <a name="vip"></a> [Vis in Practice - Visualization Solutions in the Wild](https://visinpractice.github.io/assets/vip2017/)
+Monday, October 2
+2:00PM-5:55PM
+207 Lecture Hall
 
-Bernd Hentschel, RWTH Aachen University  
-Daniela Oelke, Siemens AG  
-Justin Talbot, Tableau Research  
+Bernd Hentschel, RWTH Aachen University
+Daniela Oelke, Siemens AG
+Justin Talbot, Tableau Research
 
 Contact: vip@ieeevis.org
 

--- a/year/2019/info/week-at-a-glance.md
+++ b/year/2019/info/week-at-a-glance.md
@@ -36,11 +36,11 @@ permalink: /year/2019/info/week-at-a-glance
 
 *10:30-10:50AM*
 
-* Break 
+* Break
 
 *12:20-2:20PM*
 
-* Lunch Break 
+* Lunch Break
 
 <a name="sunday-second">*2:20-5:40PM*</a>
 
@@ -55,7 +55,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *3:50-4:10PM*
 
-* Break 
+* Break
 
 <a name="sunday-third">*4:10-5:40PM*</a>
 
@@ -81,16 +81,16 @@ permalink: /year/2019/info/week-at-a-glance
 
 * [Posters](/year/2019/info/posters) (location: Exhibition Hall A)
 * LDAV (location: Ballroom A)
-* [VisInPractice](https://visinpractice.github.io) (location: Ballroom B)
+* [VisInPractice](https://visinpractice.github.io/assets/vip2019/) (location: Ballroom B)
 * [VAST Challenge](https://vast-challenge.github.io/2019/) (location: Ballroom C)
 
 *10:30-10:50AM*
 
-* Break 
+* Break
 
 *12:20-2:20PM*
 
-* Lunch Break 
+* Lunch Break
 
 <a name="monday-second">*2:20-5:40PM*</a>
 
@@ -105,7 +105,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *3:50-4:10PM*
 
-* Break 
+* Break
 
 <a name="monday-third">*4:10-5:40PM*</a>
 
@@ -133,7 +133,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *11:00-11:20AM*
 
-* Break 
+* Break
 
 <a name="tuesday-third">*11:20AM-12:20PM*</a>
 
@@ -141,7 +141,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *12:20-2:20PM*
 
-* Lunch Break 
+* Lunch Break
 
 <a name="tuesday-fourth">*2:20-2:35PM*</a>
 
@@ -163,7 +163,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *3:50-4:10PM*
 
-* Break 
+* Break
 
 <a name="tuesday-fifth">*4:10-5:40PM*</a>
 
@@ -196,7 +196,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *10:30-10:50AM*
 
-* Break 
+* Break
 
 <a name="wednesday-second">*10:50AM-12:20PM*</a>
 
@@ -204,12 +204,12 @@ permalink: /year/2019/info/week-at-a-glance
 * [Animation and Sports](/year/2019/info/papers-sessions#animationsports) (location: Ballroom B)
 * [Multivariate & Multidimensional Data](/year/2019/info/papers-sessions#multidata) (location: Ballroom C)
 * [CG&A Session 1](/year/2019/info/papers-sessions#cga1) (location: Room 8+15)
-* Application Spotlight: Does AI mean data visualization is dead? (location: Room 1) 
+* Application Spotlight: Does AI mean data visualization is dead? (location: Room 1)
 * VizSec (location: Room 2+3)
 
 *12:20-2:20PM*
 
-* Lunch Break 
+* Lunch Break
 
 *1:00-2:00PM*
 
@@ -226,7 +226,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *3:50-4:10PM*
 
-* Break 
+* Break
 
 <a name="wednesday-fourth">*4:10-5:40PM*</a>
 
@@ -262,7 +262,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *10:30-10:50AM*
 
-* Break 
+* Break
 
 <a name="thursday-second">*10:50AM-12:20PM*</a>
 
@@ -273,7 +273,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *12:20-2:20PM*
 
-* Lunch Break 
+* Lunch Break
 
 *1:00-2:00PM*
 
@@ -289,7 +289,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *3:50-4:10PM*
 
-* Break 
+* Break
 
 <a name="thursday-fourth">*4:10-5:40PM*</a>
 
@@ -313,7 +313,7 @@ permalink: /year/2019/info/week-at-a-glance
 
 *10:30-10:50AM*
 
-* Break 
+* Break
 
 <a name="friday-second">*11:00-12:00PM*</a>
 


### PR DESCRIPTION
Updating historical links so we can set up redirects from the visinpractice site to our page on ieeevis.org.

There will be a few other PRs to other branches / master, where I have tried to update all of these links. My editor is picky about whitespace at ends of lines. If this is a problem, just let me know, and I can redo the changes, but I don't anticipate it having any effect on MD / HTML rendered content.

Thanks!