### PR TITLE
Update final-information-paper-authors.md

### DIFF
--- a/content/info/presenter-information/final-information-paper-authors.md
+++ b/content/info/presenter-information/final-information-paper-authors.md
@@ -31,8 +31,6 @@ At least one author per accepted paper must register to present the work. There 
 
 **DEADLINE: September 8.** It is **mandatory** for authors of all VIS papers to submit a [recording of their paper presentation](/year/2021/info/presenter-information/talk-recording-guide). Presentations should be submitted through the IEEE submission system.
 
-We provide a PowerPoint template that can be used for your presentation.  Feel free to download the template with [imperial measurements]({{ 'assets/vis2021-16x9-imperial.pptx' | relative_url }}) or [metric measurements]({{ 'assets/vis2021-16x9-metric.pptx' | relative_url }}).
-
 ## Common Editing Mistakes and Notes from TVCG
 
 Under no circumstances will updates be accepted after 11.59 PM on August 8. We have allowed for exceptions in the past but we will be strict this year.  


### PR DESCRIPTION
Removing the link to the template, it shows up in the talk-recording guide.