### PR TITLE
Add jobs posting page

### DIFF
--- a/content/info/jobs.md
+++ b/content/info/jobs.md
@@ -112,16 +112,12 @@ Attend job fair meetup? Yes
 
 **Computer Scientist - Semi-automated methods for interacting with augmented reality in digital twins and smart cities scenarios** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
 
-[NA](NA)
-
 Contact: andreas.gerndt@dlr.de  
 Start time flexible? Yes  
 Attend job fair meetup? No
 
 
 **Computer Scientist - Software research for in-situ analysis and interactive visualization of large scientific datasets** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
-
-[NA](NA)
 
 Contact: andreas.gerndt@dlr.de  
 Start time flexible? Yes  
@@ -130,16 +126,12 @@ Attend job fair meetup? No
 
 **Computer Scientist - Interactive visualisation of trains of the future and emission data maps** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
 
-[NA](NA)
-
 Contact: andreas.gerndt@dlr.de  
 Start time flexible? Yes  
 Attend job fair meetup? No
 
 
 **Computer Scientist - Visual Analytics for big georeferenced Data** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
-
-[NA](NA)
 
 Contact: andreas.gerndt@dlr.de  
 Start time flexible? Yes  

--- a/content/info/jobs.md
+++ b/content/info/jobs.md
@@ -1,0 +1,174 @@
+---
+title: Jobs
+layout: page
+active_nav: "Program"
+permalink: /info/jobs
+---
+
+## Welcome to the VIS 2021 site for job postings
+
+We will collect job postings and display them here through out the VIS 2021 meeting. 
+
+<!--
+To submit a posting, please click "Submit Posting" in the site menu. Postings will be updated daily on this page. 
+
+For more information about the Job Fair Meetup (Thurs 10/29) please visit "Job Fair Meetup" in the site menu.
+
+Questions? Contact the Community Committee (Jaegul Choo, Karen Schloss, Hsiang-Yun Wu) at community@ieeevis.org. 
+-->
+
+# Job Postings
+
+## Academic
+**Research Professor (Open Rank) in Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+[https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics](https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics)
+
+Contact: Melanie Tory, m.tory@northeastern.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Research Scientist, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+[https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization](https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization)
+
+Contact: Melanie Tory, m.tory@northeastern.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Postdoc, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+[https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow](https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow)
+
+Contact: Melanie Tory, m.tory@northeastern.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Data Visualization Fellow** at Boston University Center for Antiracist Research (Boston, MA, USA), start date: 2021-11-01
+
+[https://bu.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&id=23&jobid=307058&company_id=15509&version=1&source=ONLINE&JobOwner=1017992&level=levelid1&levelid1=102853&startflag=2](https://bu.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&id=23&jobid=307058&company_id=15509&version=1&source=ONLINE&JobOwner=1017992&level=levelid1&levelid1=102853&startflag=2)
+
+Contact: Hannah McKinney, Research Manager, hlm@bu.edu  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+**Assistant/Associate Professor of Data Science** at Indiana University-Purdue University Indianapolis (Indianapolis, IN), start date: 2022-08-01
+
+[https://indiana.peopleadmin.com/postings/11389](https://indiana.peopleadmin.com/postings/11389)
+
+Contact: redak@iu.edu  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+**Yahoo! Founder Chair** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+[http://apply.interfolio.com/89722](http://apply.interfolio.com/89722)
+
+Contact: bsumma@tulane.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Assistant Professor** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+[http://apply.interfolio.com/96269](http://apply.interfolio.com/96269)
+
+Contact: bsumma@tulane.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Professor of Practice** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+[http://apply.interfolio.com/96257](http://apply.interfolio.com/96257)
+
+Contact: bsumma@tulane.edu  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Postdoctoral Researcher** at Montana State University (Bozeman, MT, USA), start date: 2022-08-15
+
+[https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh](https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh)
+
+Contact: Brittany Terese Fasy <brittany.fasy@montana.edu>  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Assistant Professor (Computer Science, any area)** at Montana State University (Bozeman, MT, USA), start date: 2021-08-15
+
+[https://jobs.montana.edu/postings/24335](https://jobs.montana.edu/postings/24335)
+
+Contact: Brittany Terese Fasy <brittany.fasy@montana.edu>  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Computer Scientist - Semi-automated methods for interacting with augmented reality in digital twins and smart cities scenarios** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
+
+[NA](NA)
+
+Contact: andreas.gerndt@dlr.de  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+**Computer Scientist - Software research for in-situ analysis and interactive visualization of large scientific datasets** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
+
+[NA](NA)
+
+Contact: andreas.gerndt@dlr.de  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+**Computer Scientist - Interactive visualisation of trains of the future and emission data maps** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
+
+[NA](NA)
+
+Contact: andreas.gerndt@dlr.de  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+**Computer Scientist - Visual Analytics for big georeferenced Data** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
+
+[NA](NA)
+
+Contact: andreas.gerndt@dlr.de  
+Start time flexible? Yes  
+Attend job fair meetup? No
+
+
+## Student
+**Ph.D Position in Visual Analytics for Multiple Sclerosis** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2021-12-01
+
+[https://www.ifi.uzh.ch/en/ivda/phdPositions/MS-IVDA.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/MS-IVDA.html)
+
+Contact: Jürgen Bernard  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Human-Centered Interactive Visual Data Analysis** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2022-04-01
+
+[https://www.ifi.uzh.ch/en/ivda/phdPositions/HC-IVDA.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/HC-IVDA.html)
+
+Contact: Jürgen Bernard  
+Start time flexible? Yes  
+Attend job fair meetup? Yes
+
+
+**Ph.D Position in Visual-Interactive Data Labeling** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2021-12-01
+
+[https://www.ifi.uzh.ch/en/ivda/phdPositions/VIAL.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/VIAL.html)
+
+Contact: Jürgen Bernard  
+Start time flexible? Yes  
+Attend job fair meetup? Yes

--- a/content/info/jobs.md
+++ b/content/info/jobs.md
@@ -20,147 +20,136 @@ Questions? Contact the Community Committee (Jaegul Choo, Karen Schloss, Hsiang-Y
 # Job Postings
 
 ## Academic
-**Research Professor (Open Rank) in Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
 
-[https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics](https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics)
-
-Contact: Melanie Tory, m.tory@northeastern.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Research Scientist, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
-
-[https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization](https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization)
-
-Contact: Melanie Tory, m.tory@northeastern.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Postdoc, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
-
-[https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow](https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow)
-
-Contact: Melanie Tory, m.tory@northeastern.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
+### Boston University Center for Antiracist Research
 
 **Data Visualization Fellow** at Boston University Center for Antiracist Research (Boston, MA, USA), start date: 2021-11-01
 
+
 [https://bu.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&id=23&jobid=307058&company_id=15509&version=1&source=ONLINE&JobOwner=1017992&level=levelid1&levelid1=102853&startflag=2](https://bu.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&id=23&jobid=307058&company_id=15509&version=1&source=ONLINE&JobOwner=1017992&level=levelid1&levelid1=102853&startflag=2)
 
+Start time flexible? Yes  
+Attend job fair meetup? No, please contact directly  
 Contact: Hannah McKinney, Research Manager, hlm@bu.edu  
-Start time flexible? Yes  
-Attend job fair meetup? No
-
-
-**Assistant/Associate Professor of Data Science** at Indiana University-Purdue University Indianapolis (Indianapolis, IN), start date: 2022-08-01
-
-[https://indiana.peopleadmin.com/postings/11389](https://indiana.peopleadmin.com/postings/11389)
-
-Contact: redak@iu.edu  
-Start time flexible? Yes  
-Attend job fair meetup? No
-
-
-**Yahoo! Founder Chair** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
-
-[http://apply.interfolio.com/89722](http://apply.interfolio.com/89722)
-
-Contact: bsumma@tulane.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Assistant Professor** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
-
-[http://apply.interfolio.com/96269](http://apply.interfolio.com/96269)
-
-Contact: bsumma@tulane.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Professor of Practice** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
-
-[http://apply.interfolio.com/96257](http://apply.interfolio.com/96257)
-
-Contact: bsumma@tulane.edu  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Postdoctoral Researcher** at Montana State University (Bozeman, MT, USA), start date: 2022-08-15
-
-[https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh](https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh)
-
-Contact: Brittany Terese Fasy <brittany.fasy@montana.edu>  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
-**Assistant Professor (Computer Science, any area)** at Montana State University (Bozeman, MT, USA), start date: 2021-08-15
-
-[https://jobs.montana.edu/postings/24335](https://jobs.montana.edu/postings/24335)
-
-Contact: Brittany Terese Fasy <brittany.fasy@montana.edu>  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
+### German Aerospace Center (DLR)
 **Computer Scientist - Semi-automated methods for interacting with augmented reality in digital twins and smart cities scenarios** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
-
-Contact: andreas.gerndt@dlr.de  
-Start time flexible? Yes  
-Attend job fair meetup? No
 
 
 **Computer Scientist - Software research for in-situ analysis and interactive visualization of large scientific datasets** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
 
-Contact: andreas.gerndt@dlr.de  
-Start time flexible? Yes  
-Attend job fair meetup? No
-
 
 **Computer Scientist - Interactive visualisation of trains of the future and emission data maps** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
-
-Contact: andreas.gerndt@dlr.de  
-Start time flexible? Yes  
-Attend job fair meetup? No
 
 
 **Computer Scientist - Visual Analytics for big georeferenced Data** at German Aerospace Center (DLR) (Braunschweig, Germany), start date: 2022-01-01
 
-Contact: andreas.gerndt@dlr.de  
+
 Start time flexible? Yes  
-Attend job fair meetup? No
+Attend job fair meetup? No, please contact directly  
+Contact: andreas.gerndt@dlr.de  
+### Indiana University-Purdue University Indianapolis
+**Assistant/Associate Professor of Data Science** at Indiana University-Purdue University Indianapolis (Indianapolis, IN), start date: 2022-08-01
 
 
+[https://indiana.peopleadmin.com/postings/11389](https://indiana.peopleadmin.com/postings/11389)
+
+Start time flexible? Yes  
+Attend job fair meetup? No, please contact directly  
+Contact: redak@iu.edu  
+### Montana State University
+**Postdoctoral Researcher** at Montana State University (Bozeman, MT, USA), start date: 2022-08-15
+
+
+[https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh](https://montana.qualtrics.com/jfe/form/SV_03wF1MSY4Y0T2Sh)
+
+**Assistant Professor (Computer Science, any area)** at Montana State University (Bozeman, MT, USA), start date: 2021-08-15
+
+
+[https://jobs.montana.edu/postings/24335](https://jobs.montana.edu/postings/24335)
+
+Start time flexible? Yes  
+Attend job fair meetup? Yes  
+Contact: Brittany Terese Fasy <brittany.fasy@montana.edu>  
+### Roux Institute, Northeastern University
+**Research Professor (Open Rank) in Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+
+[https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics](https://careers.hrm.northeastern.edu/en-us/job/506730/research-professor-and-roux-institute-member-open-rank-visualization-and-visual-analytics)
+
+**Research Scientist, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+
+[https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization](https://careers.hrm.northeastern.edu/cw/en-us/job/507158/research-scientist-data-visualization)
+
+**Postdoc, Data Visualization** at Roux Institute, Northeastern University (Portland, Maine, USA), start date: 2021-11-01
+
+
+[https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow](https://careersmanager.pageuppeople.com/879/cw/en-us/job/507645/visualization-postdoctoral-fellow)
+
+Start time flexible? Yes  
+Attend job fair meetup? Yes  
+Contact: Melanie Tory, m.tory@northeastern.edu  
+### Tulane University
+**Yahoo! Founder Chair** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+
+[http://apply.interfolio.com/89722](http://apply.interfolio.com/89722)
+
+**Assistant Professor** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+
+[http://apply.interfolio.com/96269](http://apply.interfolio.com/96269)
+
+**Professor of Practice** at Tulane University (New Orleans, LA, USA), start date: 2022-07-01
+
+
+[http://apply.interfolio.com/96257](http://apply.interfolio.com/96257)
+
+Start time flexible? Yes  
+Attend job fair meetup? Yes  
+Contact: bsumma@tulane.edu  
+## Industry
+### Kitware
+**Scientific Visualization Developer** at Kitware (USA - Multiple Locations), start date: 2021-11-01
+
+
+[https://jobs.lever.co/kitware?team=Scientific%20Computing](https://jobs.lever.co/kitware?team=Scientific%20Computing)
+
+**Qt Application Designer** at Kitware (USA - Multiple Locations), start date: 2021-11-01
+
+
+[https://jobs.lever.co/kitware?team=Scientific%20Computing](https://jobs.lever.co/kitware?team=Scientific%20Computing)
+
+**Senior Full-Stack Web Developer for Scientific Applications** at Kitware (USA - Multiple Locations), start date: 2021-11-01
+
+
+[https://jobs.lever.co/kitware?team=Data%20and%20Analytics](https://jobs.lever.co/kitware?team=Data%20and%20Analytics)
+
+**3D Computer Vision Researcher** at Kitware (USA - Multiple Locations), start date: 2021-01-10
+
+
+[https://jobs.lever.co/kitware?team=Computer%20Vision](https://jobs.lever.co/kitware?team=Computer%20Vision)
+
+Start time flexible? Yes  
+Attend job fair meetup? Yes  
+Contact: John Westbrook; john.westbrook@kitware.com  
 ## Student
+### University of Zurich (UZH)
 **Ph.D Position in Visual Analytics for Multiple Sclerosis** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2021-12-01
+
 
 [https://www.ifi.uzh.ch/en/ivda/phdPositions/MS-IVDA.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/MS-IVDA.html)
 
-Contact: Jürgen Bernard  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
 **Human-Centered Interactive Visual Data Analysis** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2022-04-01
+
 
 [https://www.ifi.uzh.ch/en/ivda/phdPositions/HC-IVDA.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/HC-IVDA.html)
 
-Contact: Jürgen Bernard  
-Start time flexible? Yes  
-Attend job fair meetup? Yes
-
-
 **Ph.D Position in Visual-Interactive Data Labeling** at University of Zurich (UZH) (Zurich, Switzerland), start date: 2021-12-01
+
 
 [https://www.ifi.uzh.ch/en/ivda/phdPositions/VIAL.html](https://www.ifi.uzh.ch/en/ivda/phdPositions/VIAL.html)
 
-Contact: Jürgen Bernard  
 Start time flexible? Yes  
-Attend job fair meetup? Yes
+Attend job fair meetup? Yes  
+Contact: Jürgen Bernard  


### PR DESCRIPTION
Here is a first pass on the jobs posting page, modeled after last year's -> https://sites.google.com/view/vis-2020-job-postings

We're working on additional formatting, nesting, etc.