### PR TITLE
Added actual page for IEEE governance structure

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -407,7 +407,7 @@ menu:
             columns:
               - links:
                   - text: "IEEE Governance Structure"
-                    url: "https://drive.google.com/file/d/1CzoEKf0CiHvybLsB44OcoD9OFiCTT210/view"
+                    url: "/governance/IEEE-governance-structure"
                   - text: "Best Paper Process"
                     url: "/governance/best-paper-process"
 

--- a/governance/IEEE-governance-structure.md
+++ b/governance/IEEE-governance-structure.md
@@ -1,0 +1,12 @@
+---
+title: IEEE Governance Structure
+layout: page
+permalink: /governance/IEEE-governance-structure
+---
+
+## IEEE Governance Structure
+
+Here is a link to the [old Charter Version](https://drive.google.com/file/d/1CzoEKf0CiHvybLsB44OcoD9OFiCTT210/view).
+
+This page has to be updated...
+


### PR DESCRIPTION
The IEEE governance structure link now points to an actual page instead of a Google Docs link.