### PR TITLE
Update Plan S blog post with UKRI announcement details

### DIFF
--- a/_posts/2022-05-11-plublishing-under-plan-s.md
+++ b/_posts/2022-05-11-plublishing-under-plan-s.md
@@ -1,6 +1,6 @@
 ---
-title: Publishing papers covered under Plan-S 
-description: Publishing papers covered under Plan-S 
+title: Publishing papers covered under Plan S 
+description: Publishing papers covered under Plan S 
 layout: blog-page
 active_nav: Blog
 authors: The VIS Open Practices Committee
@@ -9,20 +9,20 @@ author_contact: open_practices@ieeevis.org
 permalink: /blog/plublishing-under-plan-s
 ---
 
-**What is Plan-S?**
+**What is Plan S?**
 
 [Plan S](https://www.coalition-s.org/faq-theme/publication-fees-costs-prices-business-models/) is an open-access initiative that was started in 2018. Specific state-funded research organizations and institutions have signed on to Plan S, which requires that scientists and researchers whose work has been funded by them publish said work in open repositories or in journals that provide free access to manuscripts. More specifically, authors covered by Plan S should be able to make their accepted manuscript available for free and published under an Open License (such as CC-BY). 
 
-The policy at IEEE for accommodating authors whose papers are covered under Plan-S is currently evolving. At present, IEEE works with authors’ constraints on a case-by-case basis. 
+The policy at IEEE for accommodating authors whose papers are covered under Plan S is currently evolving. At present, IEEE works with authors’ constraints on a case-by-case basis. 
 
 **IEEE VIS is committed to helping any author affected by Plan-S find an accommodation so their work can appear at VIS and on IEEE Xplore.**
 
 **For journal papers:**
 
-Currently, TVCG as a hybrid journal is not Plan-S compliant.
+Currently, TVCG as a hybrid journal is not Plan S compliant.
 
-Here are example solutions that has been used in the past:
-You would not be able to pay the TVCG article processing charge using money from your Plan-S funder in order to satisfy your requirements. However, you could pay that article processing charge using other funds to appear in TVCG.
+Here are example solutions that have been used in the past:
+You would not be able to pay the TVCG article processing charge using money from your Plan S funder in order to satisfy your requirements. However, you could pay that article processing charge using other funds to appear in TVCG.
 Instead of appearing in TVCG, your VIS paper could appear in the fully-open-access IEEE Open Journal of the Computer Society. We would encourage you to cite papers as appearing in "IEEE Open Journal of the Computer Society (IEEE VIS 2022)”.
 
 **For conference papers:**
@@ -34,8 +34,18 @@ If you have any questions, please reach out to the VIS Open Practices chairs (Lo
 
 **For everybody:**
 
-All IEEE VIS authors have the right to post a preprint of their submitted or accepted paper to an open access repository (see the [open practices page](http://ieeevis.org/year/2022/info/open-practices/open-practices)). Doing so is good for the community, but not sufficient for Plan-S compliance. Once accepted, it would be beneficial to label the paper as “Accepted at IEEE VIS 2022".
+All IEEE VIS authors have the right to post a preprint of their submitted or accepted paper to an open access repository (see the [open practices page](http://ieeevis.org/year/2022/info/open-practices/open-practices)). Doing so is good for the community, but not sufficient for Plan S compliance. Once accepted, it would be beneficial to label the paper as “Accepted at IEEE VIS 2022".
 
-Please let us know when you submit your camera-ready paper whether you believe that your paper is covered under Plan-S. There will be a field on PCS where you can note this and provide details about your funding agency. We will follow up with you individually with options and next steps to ensure your publication can appear in VIS.
+Please let us know when you submit your camera-ready paper whether you believe that your paper is covered under Plan S. There will be a field on PCS where you can note this and provide details about your funding agency. We will follow up with you individually with options and next steps to ensure your publication can appear in VIS.
 
 As VIS papers may end up published under different venues on IEEE Xplore (e.g., TVCG, OJCS, Proc. VIS) we are exploring the option of creating a VIS Anthology website that curates a list of all accepted VIS manuscripts.
+
+**Notes regarding specific funders:**
+
+**UKRI:** Update 2022-07-14: On 2022-05-20, IEEE and UKRI came to [an agreement](https://open.ieee.org/ieee-compliance-with-ukri/) under which authors could be in compliance using two routes. For TVCG papers, Route 2 is the most viable option. Open access and other publications costs like article processing charges for papers can't be paid for with UKRI grant money. To be in compliance, **authors must, within 12 months**:
+* Deposit the camera-ready paper in an institutional or subject repository (e.g. [OSF Preprints](https://osf.io/preprints/) or [arXiv](https://arxiv.org/)).
+* Use a [CC BY license](https://creativecommons.org/licenses/by/4.0/) for the repository version, which will be provided to the author by IEEE as long as the funder is properly identified. To request this license, authors should send a request to IEEEs Intellectual Property Rights group at copyrights@ieee.org as soon as they submit their paper for review.
+* Include this text in the `Acknowledgements` section:
+     > For the purpose of open access, the author(s) has applied a Creative Commons Attribution (CC BY) license to any Accepted Manuscript version arising.
+
+See [the agreement announcement](https://open.ieee.org/ieee-compliance-with-ukri/) and [UKRI Open Access Policy slides](https://www.ukri.org/wp-content/uploads/2022/02/UKRI-090222-UKRIOpenAccessPolicy-InformationPack.pdf) for more details.


### PR DESCRIPTION
It's probably not worth creating a new blog post for this, but it is useful to share with the UKRI-funded authors in one place. 

One question: Is there any standard way to easily communicate the update date in addition to the original blog date?