### PR TITLE
fix: early registration  deadline

### DIFF
--- a/content/info/registration/conference-registration.md
+++ b/content/info/registration/conference-registration.md
@@ -35,7 +35,7 @@ The 2022 IEEE Visualization and Visual Analytics Conference, running from Octobe
 <table>
   <tr>
     <th>Category</th>
-    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 7</b>)</th>
+    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 16</b>)</th>
     <th>Late Reg fee USD (Ends Sept. 16)</th>
   </tr>
 <tr>
@@ -58,7 +58,7 @@ The 2022 IEEE Visualization and Visual Analytics Conference, running from Octobe
 <table>
   <tr>
     <th>Category</th>
-    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 7</b>)</th>
+    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 16</b>)</th>
     <th>Late Reg fee USD (Ends Sept. 16)</th>
   </tr>
 <tr>
@@ -90,7 +90,7 @@ The 2022 IEEE Visualization and Visual Analytics Conference, running from Octobe
 <table>
   <tr>
     <th>Category</th>
-    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 7</b>)</th>
+    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 16</b>)</th>
     <th>Late Reg fee USD</th>
   </tr>
 <tr>
@@ -175,7 +175,7 @@ The 2022 IEEE Visualization and Visual Analytics Conference, running from Octobe
 <table>
   <tr>
     <th>Category</th>
-    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 7</b>)</th>
+    <th>Early Reg fee USD (Ends <s>Sept 2</s> <b>Extended: Sept 16</b>)</th>
     <th>Late Reg fee USD</th>
   </tr>
 <tr>


### PR DESCRIPTION
Extending the early registration is not correctly shown in the table.
![image](https://user-images.githubusercontent.com/19774198/189488848-17337e8d-0595-4d40-bddb-1ee0f9e9c9a0.png)

It still says Sept 7 in the table