### PR TITLE
Updated chair and affiliation information

### DIFF
--- a/content/info/committees/conference-committee.md
+++ b/content/info/committees/conference-committee.md
@@ -9,62 +9,66 @@ permalink: /info/committees/conference-committee
 | | |
 |---
 | **General Chairs** | |
-| TBD | *TBD* |
+| Tim Dwyer | *Monash University* |
+| Sarah Goodwin | *Monash University* |
+| Michael Wybrow | *Monash University* |
 |---
 | **Program Chairs** | |
-| Gautam Chaudhary | *Alcon* |
+| Gautam Chaudhary | *Zenith Solutions* |
 | Joshua A. Levine | *University of Arizona* |
+| Lane Harrison | *Worcester Polytechnic Institute* |
+| Kate Isaacs | *University of Utah* | 
 |---
 | **Overall Paper Chairs** | |
-| Helwig Hauser | *University of Bergen* |
-| Bongshin Lee | *Microsoft Research* |
-| Anders Ynnerman | *Linköping University* |
+| Tamara Munzner | *University of British Columbia* |
+| Jarke van Wijk | *Eindhoven University of Technology* |
+| John Stasko | *Georgia Tech* |
 |---
 | **Area 1 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Theoretical & Empirical** |
-| Jian Chen | *The Ohio State University* |
-| Christopher Collins | *Ontario Tech University* |
+| Adam Perer | *Carnegie Mellon University* |
+| Alexander Lex | *University of Utah* | 
 |---
 | **Area 2 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Applications** | |
-| Hamish A. Carr | *University of Leeds* |
+| Tatiana Von Landesberger | *University of Cologne* | 
 | Yingcai Wu | *Zhejiang University* |
 |---
 | **Area 3 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Systems & Rendering** | |
-| Michael Gleicher | *University of Wisconsin-Madison* |
-| Tobias Isenberg | *INRIA* |
+| Chaoli Wang | *University of Notre Dame* |
+| Tobias Isenberg | *Inria and Université Saris-Saclay* |
 |---
 | **Area 4 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Representations & Interaction** | |
-| Anastasia Bezerianos | *Université Paris Saclay* |
-| T. J. Jankun-Kelly | *Mississippi State University* |
+| T. J. Jankun-kelly | *Mississippi State University* |
+| Pierre Dragicevic | *Inria and Université de Bordeaux* |
 |---
 | **Area 5 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Data Transformations** | |
-| M. Eduard Gröller | *TU Wien* |
 | Michael Sedlmair | *University of Stuttgart* |
+| Ivan Viola | *KAUST* |
 |---
 | **Area 6 Paper Chairs &nbsp;&nbsp;&nbsp;—** | **Analytics & Decisions** | |
-| Jinwook Seo | *Seoul National University* |
+| Wenwen Dou | *University of North Carolina at Charlotte* |
 | Alex Endert | *Georgia Tech* |
 |---
 | **Short Papers Chairs** | |
-| Michelle Borkin | *Northeastern University* |
-| Christoph Garth | *University of Kaiserslautern* |
-| Jonathan Roberts | *Bangor University* |
-| Chaoli Wang | *University of Notre Dame* |
+| Jonathan Roberts |  |
+| Christoph Garth | *University of Kaiserslautern-Landau* |
+| Takayuki Itoh | *Ochanomizu University* |
+| Hongfeng Yu | *University of Nebraska–Lincoln* |
 |---
 | **Posters Chairs** | |
-| Vijay Natarajan | *IISc Bangalore* |
-| Adam Perer | *Carnegie Mellon University* |
-| Jessica Hullman | *Northwestern University* |
+| Nan Cao | *Tongji University* |
 | Barbora Kozlíková | *Masaryk University* |
+| Jiazhi Xia | *Central South University* |
+| Wesley Willett | *University of Calgary* |
 |---
 | **Panels Chairs** | |
-| Michael Correll | *Tableau Software* |
+| Cagatay Turkay | *University of Warwick* |
+| Hsiang-Yun Wu | *St. Pölten University of Applied Sciences* |
 | Yunhai Wang | *Shandong University* |
-| Hsiang-Yun Wu | *TU Wien* |
 |---
 | **Tutorial Chairs** | |
-| Stefan Bruckner | *University of Bergen* |
-| Christophe Hurter | *French Civil Aviation University* |
-| Mengchen Liu | *Microsoft Research* |
+| Mengchen Liu | *Microsoft* |
+| Charles Perin | *University of Victoria* |
+| Kai Lawonn | *University of Jena* |
 |---
 | **Application Spotlights** | |
 | Soumya Dutta | *Los Alamos National Laboratory* |
@@ -73,154 +77,116 @@ permalink: /info/committees/conference-committee
 |---
 | **Open Practices** | |
 | Lonni Besançon | *Monash University* |
-| Carlos Scheidegger | *University of Arizona* |
 | Cody Dunne | *Northeastern University* |
+| Michael Correll | *Tableau Research* |
 |---
 | **Workshop Chairs** | |
-| Johanna Beyer | *Harvard University* |
-| Filip Sadlo | *Heidelberg University* |
-| Panpan Xu | *Amazon AWS AI* |
+| Julian Tierny | *CNRS & Sorbonne Universite* |
+| Stefan Bruckner | *University of Bergen* |
+| Narges Mahyar | *University of Massachusetts Amherst* |
+| Panpan Xu |  |
 |---
 | **Arts Program Chairs** | |
-| Uta Hinrichs | *University of St. Andrews* |
-| Charles Perin | *University of Victoria* |
+| Xavier Ho | *Monash University* |
+| Uta Hinrichs | ** |
+| Rebecca Ruige Xu | *Syracuse University* |
 |---
 | **Vis in Practice Chairs** | |
-| Anamaria Crisan | *Tableau Software* |
-| Zhicheng (Leo) Liu | *Adobe* | 
-| Sudhanshu Kumar Semwal | *University of Colorado* |
+| Alexander Bock | *Linköping University* |
+| Ayan Biswas | *Los Alamos National Laboratory* |
 |---
 | **Doctoral Colloquium Chairs**| |
-| Nan Cao | *Tongji University* |
-| Maxime Cordeil | *Monash University* |
-| Katherine Isaacs | *University of Arizona* |
+| Kate Isaacs | *University of Arizona* |
 | Karen B. Schloss | *University of Wisconsin* |
+| Christophe Hurter | *ENAC (French Civil Aviation University) and University of Toulouse* |
 |---
-| **Fast Forward & Video Previews Chairs** | |
+| **Fast Forward & Video Chairs** | |
+| Soumya Dutta | *Indian Institute of Technology Kanpur (IIT Kanpur)* |
 | Arjun Srinivasan | *Tableau Research* |
-| Jun Tao | *Sun Yat-sen University* |
+| Siming Chen | *Fudan University* |
+| Jun Tao | ** |
 |---
 | **Publications Chairs** | |
-| Arvind Satyanarayan | *Massachusetts Institute of Technology* |
-| Jian Zhao | *University of Waterloo* |
-| Katerina Vrotsou | *Linkoping University* |
+| Arvind Satyanarayan | ** |
+| Zhicheng Liu | *University of Maryland College Park* |
+| Katerina Vrotsou | *Linköping University* |
 |---
 | **Elections Chairs** | |
-| Bettina Speckmann | *TU Eindhoven* |
 | Emily Wall | *Emory University* |
-| Wesley Willett | *University of Calgary* |
+| Ali Sarvghad | *University of Massachusetts Amherst* |
 |---
 | **Meetup Chairs** | |
-| Ayan Biswas | *Los Alamos National Lab* |
-| Evanthia Dimara | *Utrecht University* |
+| Carmen Hull | *Northeastern* |
+| Cindy Xiong | *UMass Amherst* |
 | Yang Shi | *Tongji University* |
 |---
 | **Community Chairs** | |
-| Lane Harrison | *Worcester Polytechnic Institute* |
+| Bon Adriel Aseniero | ** |
 | Qing Chen | *Tongji University* |
 | Alfie Abdul-Rahman | *King's College London* |
 |---
 | **Student Volunteers Chairs** | |
-| Beatrice Gobbo | *Politecnico di Milano* |
-| Juan Trelles | *University of Illinois Chicago* |
-| Chenguang Xu | *Universty of Oklahoma (local)* |
 | Kun-Ting Chen | *University of Stuttgart* |
-| Keke Wu | *University of Colorado Boulder* |
+| Keke Wu | *University of North Carolina at Chapel Hill* |
+| Katy Williams | *University of Arizona* |
+| Noëlle Rakotondravony | *Worcester Polytechnic Institute* |
+| Vahid Pooryousef | *Monash University* |
 |---
 | **Publicity Chairs** | |
-| Mennatallah El-Assady | *ETH AI Center* |
-| John Alexis Guerra Gómez | *Assistant Teaching Professor Northeastern University Silicon Valley* |
-| Alvitta Ottley | *Washington University in St. Louis* |
+| Lace Padilla | *University of California, Merced* |
+| Alvitta Ottley | *Washington University in Saint Louis* |
 |---
 | **Inclusivity Chairs** | |
-| Lace Padilla | *University of California Merced* |
-| Vetria Byrd | *Purdue University* |
+| John Alexis Guerra Gómez | *Northeastern University, Silicon Valley* |
+| Vetria Byrd | ** |
 |---
 | **Accessibility Chairs** | |
-| Yea-Seul Kim | *University of Wisconsin Madison* |
+| Kim Marriott | *Monash University* |
 | Dominik Moritz | *Carnegie Mellon University* |
 |---
 | **Supporters Chairs** | |
+| Maxime Cordeil | *The University of Queensland* |
+| Benjamin Bach | ** |
+| Vidya Setlur | *Tableau Research* |
+| Barrett Ens | *Monash University* |
+| Christy Ling | ** |
+| Andrew Cunningham | *University of South Australia* |
 | Eli T. Brown | *DePaul University* |
-| Benjamin Bach | *University of Edinburgh* |
-| Jürgen Bernhard | *University of Zurich* |
 |---
 | **Finance Chairs** | |
-| Loretta Auvil | *University of Illinois at Urbana-Champaign* |
-| Maria Valez | *CA Technologies* |
+| Loretta Auvil | *University of Illinois at Urbana Champaign* |
+| Maria C. Velez | *Marvel Analytics* |
+| Bhavana Doppalapudi | ** |
 |---
-| **Incoming General Chairs (VIS23)** | |
-| Tim Dwyer | *Monash University* |
-| Sarah Goodwin | *Monash University* |
-| Michael Wybrow | *Monash University* |
+| **Incoming General Chairs (VIS24)** | |
+| Paul Rosen | *University of Utah* |
+| Kristin Potter | *National Renewable Energy Lab* |
+| Remco Chang | *Tufts* |
 |---
 | **Archive Chairs** | |
-| Samuel Huron | *Télécom ParisTech* |
-| Carolina Nobre | *Harvard University* |
-| Kyle Hall | *University of Calgary* |
+| Xiting Wang | *Microsoft* |
+| Carolina Nobre | *University of Toronto* |
+| Kyle Hall | ** |
 |---
 | **Web Chairs** | |
-| Dylan Cashman | *Novartis* |
-| Rebecca Kehlbeck | *University of Konstanz* |
+| Dylan Cashman | ** |
 | Steve Petruzza | *Utah State University* |
-| Janos Zimmermann | *University of Magdeburg* |
+| Janos Zimmermann | ** |
+| Rebecca Kehlbeck | *University of Konstanz* |
+| Mashrur Rashik | *University of Massachusetts Amherst* |
+| Jim Smiley | *Monash University* |
 |---
 | **Technology Chairs** | |
-| Alex Bock | *Linköping University* |
-| Johannes Knittel | *University of Stuttgart* |
+| Kadek Satriadi | *Monash University* |
+| John Wenskovitch | *Pacific Northwest National Laboratory* |
 | John Thompson | *Microsoft Research* |
-| John Wenskovitch | *PNNL* |
-|---
-| **Virtual VIS Chairs** | |
-| Gautam Chaudhary | *Alcon* |
-| Amy Gooch | *University of Utah* |
-| Paul Rosen | *University of Central Florida* |
-| Daniel Baum | *Zuse Institute Berlin* |
-| Harish Doraiswamy | *Microsoft Research* |
-| Chris Weaver | *University of Oklahoma* |
+| Johannes Knittel | *University of Stuttgart* |
 |---
 | **VAST Challenge Chairs** | |
-| Kristin Cook | *Pacific Northwest National Laboratory* |
+| Jereme Haack | ** |
+| Alvitta Ottley | ** |
 | R. Jordan Crouser | *Smith College* |
 |---
 | **SciVis Contest Chairs** | |
-| Alex Razoumov | *WestGrid* |
-| Divya Banesh | *Los Alamos National Lab* |
-|---
-| **Bio+MedVis Challenges Chairs** | |
-| Thomas Höllt | *TU Delft* |
-| Zeynep Gumus | *Mount Sinai School of Medicine* |
-| Daniel Jönsson | *Linköping University* |
-| Renata Raidou | *TU Wien* |
-|---
-| **VDS Symposium Liaison**| |
-| Liang Gou | *Bosch Research* |
-| Alvitta Ottley | *Washington University in St. Louis* |
-| Anamaria Crisan | *Tableau Software* |
-|---
-| **LDAV Symposium Liaisons**| |
-| Chaoli Wang | *University of Notre Dame* |
-| Peer-Timo Bremer | *Lawrence Livermore National Laboratory* |
-| Kristi Potter | *National Renewable Energy Lab* |
-|---
-| **VIZSec Symposium Liaison** | |
-| Chris Bryan | *Arizona State University* |
-|---
-| **Vis4DH Workshop Liaison** | |
-| Houda Lamqaddam | *KU Leuven* |
-| Alfie Abdul-Rahman | *King's College London* |
-|---
-| **VISxAI Workshop Liaisons** | |
-| Adam Perer | *Carnegie Mellon University* |
-| Angie Boggust | *Massachusetts Institute of Technology* |
-| Fred Hohman | *Apple* |
-| Hendrik Strobelt | *MIT-IBM Watson AI Lab* |
-| Mennatallah El-Assady | *ETH AI Center* |
-| Zijie Jay Wang | *Georgia Tech* |
-|---
-| **BELIV Workshop Liaisons** | |
-| Anastasia Bezerianos | *Université Paris Saclay* |
-| Kyle Hall | *University of Calgary* |
-| Samuel Huron | *Télécom ParisTech* |
-| Matthew Kay | *Northwestern University* |
-| Miriah Meyer | *Linköping University* |
+| Divya Banesh | *Los Alamos National Laboratory* |
+| Tim Gerrits | *RWTH Aachen University* |


### PR DESCRIPTION
Updated conference committee information to reflect info for VIS 2023. More specifically, added chair names and affiliation information. Not including associated events at this point as information is incomplete.