### PR TITLE
Update footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -72,7 +72,7 @@
 
             <div class="flex flex-col lg:flex-row justify-between uppercase text-sm">
                 <div>
-                    <span>&copy; {{ site.year }} IEEE. Sponsored by the IEEE Computer Society and the Visualization and Graphics Technical Committee.</span>
+                    <span>&copy; {{ site.year }} IEEE. Sponsored by the IEEE Computer Society and the Visualization and Graphics Technical Community.</span>
                 </div>
                 <div class="mt-4 lg:mt-0">
                     <a class="footer__link" href="https://www.ieee.org/security-privacy.html" target="_new">IEEE Privacy Policy</a>


### PR DESCRIPTION
VGTC does not stand for Visualization and Graphics Technical Committee anymore. It now stands for Visualization and Graphics Technical Community.