### PR TITLE
Revert "Bump tzinfo from 1.2.9 to 1.2.11"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.11)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
Reverts ieee-vgtc/ieeevis.org#1927