### PR TITLE
Updating preview video and rep image deadlines to be Sep 12

### DIFF
--- a/content/info/call-participation/posters.md
+++ b/content/info/call-participation/posters.md
@@ -48,7 +48,7 @@ At the time of submission, it is required by the authors to state explicitly in 
 ### IMPORTANT DATES
 * Submission Deadline: **Thursday, June 20, 2024**
 * Notification of Acceptance: **Saturday, July 19, 2024**
-* (Optional) [Video Preview](/year/2024/info/presenter-information/fast-forward-and-video-previews) Submission: **Thursday, August 22, 2024**
+* (Optional) [Video Preview](/year/2024/info/presenter-information/fast-forward-and-video-previews) Submission: **Thursday, September 12, 2024**
 * Final Submission of camera-ready (1) 2-page Poster Summary PDF and (2) full Poster PDF: **Thursday, August 29, 2024**
 
 All deadlines are at 11:59pm (23:59) AoE **Anywhere on Earth [(AoE)](https://time.is/Anywhere_on_Earth)**.

--- a/content/info/presenter-information/fast-forward-and-video-previews.md
+++ b/content/info/presenter-information/fast-forward-and-video-previews.md
@@ -13,7 +13,7 @@ Please **read the following instructions carefully** and submit your
 - Aug. 22: VIS Full/Short Papers
 - Aug. 22: [TVCG/CG&amp;A presentations](/year/2024/info/call-participation/partnerships) presentations
 VIS Full/Short Papers
-- Aug. 22: All other events.
+- Sep. 12: All other events.
 
 Video Previews are a great opportunity to publicize your work or event to a wide audience and invite people to join your presentation and read your paper. Video Previews are accessible from the conference website on the VIS YouTube channel prior to, during, and after the conference.
 

--- a/content/info/presenter-information/talk-guide.md
+++ b/content/info/presenter-information/talk-guide.md
@@ -36,12 +36,12 @@ Work must be submitted via the provided link on the dates listed below.
 **Video Previews:**
   * VIS Full/Short Papers: Aug. 22
   * TVCG/CG&A Presentations: Aug. 22
-  * All Other Events:  Aug. 22
+  * All Other Events:  Sep. 12
 
 **Representative Image and Caption:**
   * Full/Short VIS Papers: Aug. 22
   * TVCG/CG&A Presentations: Aug. 22
-  * All Other Events: Aug. 22
+  * All Other Events: Sep. 12
 
 
 ## Presentation Recommendations and Powerpoint Template


### PR DESCRIPTION
Material Upload deadline has been moved from Aug 22 to Sep 12 for all events other than Full/Short/TVCG/CG&A