### PR TITLE
Clean Up Preview Videos Page

### DIFF
--- a/content/info/presenter-information/fast-forward-and-video-previews.md
+++ b/content/info/presenter-information/fast-forward-and-video-previews.md
@@ -11,8 +11,7 @@ contact: ff@ieeevis.org
 Please **read the following instructions carefully** and submit your
 25-second video for the online Video Previews by the following deadlines:
 - Aug. 22: VIS Full/Short Papers
-- ~~Aug. 22~~ Sep. 12: [TVCG/CG&amp;A presentations](/year/2024/info/call-participation/partnerships) presentations
-VIS Full/Short Papers
+- ~~Aug. 22~~ Sep. 12: [TVCG/CG&amp;A presentations](/year/2024/info/call-participation/partnerships)
 - Sep. 12: All other events.
 
 Video Previews are a great opportunity to publicize your work or event to a wide audience and invite people to join your presentation and read your paper. Video Previews are accessible from the conference website on the VIS YouTube channel prior to, during, and after the conference.


### PR DESCRIPTION
Clean up preview videos page. There was duplicated text on the TVCG/CGA presentations deadline bullet