### PR TITLE
fix: mark workshops as new in navigation

### DIFF
--- a/src/data/navigation.yml
+++ b/src/data/navigation.yml
@@ -56,7 +56,7 @@ menu:
                     is_new: true
                   - text: "Workshops"
                     url: "/info/call-participation/workshops"
-                    is_new: false
+                    is_new: true
                   # - text: "Panels"
                   #   url: "/info/call-participation/panels"
                   #   is_new: false


### PR DESCRIPTION
Minor change: Added the "new" tag for the workshops.