### PR TITLE
fix: removed incorrect references to year 2026

### DIFF
--- a/src/pages/blog/2025-11-11-vis-2025-OPC-blog.md
+++ b/src/pages/blog/2025-11-11-vis-2025-OPC-blog.md
@@ -1,31 +1,34 @@
----  
-title: Road's End - Reflections on the VIS 2026 Review Process
-description: Reflections by the Overall Paper Chairs on the IEEE VIS 2026 review process, including reviewer workload, student reviewers, and public peer review experiments.
+---
+title: Road's End - Reflections on the VIS 2025 Review Process
+description: Reflections by the Overall Paper Chairs on the IEEE VIS 2025 review process, including reviewer workload, student reviewers, and public peer review experiments.
 layout: /src/layouts/BlogPageLayout.astro
 active_nav: Blog
-authors: The VIS 2026 Overall Paper Chairs
+authors: The VIS 2025 Overall Paper Chairs
 author_contact: opc@ieeevis.org
 date: 2025-11-11
 ---
-IEEE VIS 2026 in Vienna has come to a close and we—Niklas Elmqvist, Holger Theisel, and Melanie Tory, the 2026 Overall Papers Chairs (OPCs)—have reached the end of the road. Melanie will continue as OPC for VIS 2026 in Boston together with Tobias Isenberg (Inria) and Alex Endert (Georgia Tech), whereas Niklas and Holger (together with OPC assistant Petra Specht) can step down with what we think was a successful full paper program behind us. But before we do, we would like to report on the changes we made to the VIS review process this year.
 
-To help us understand the impact of these changes, we administered a survey to the IEEE VIS 2026 international program committee (IPC) asking about their experiences this year and their thoughts about the coming year. We can summarize the findings from 97 responses as follows:
--	The review load of approximately six papers (half as primary and half as secondary) was perceived to be just about right for most IPC members.
--	61.9% of IPC members felt that keeping three reviewers (2 PC members and 1 external) was acceptable; 23.7% wanted to go back to four reviewers, and 14.4% were undecided.
--	Allowing for an additional week for submitting supplemental materials was almost uniformly seen as positive, with 83.5% in favor, 8.2% undecided, and 8.2% against.
--	The new student reviewer program was perceived as a positive initiative that most (69.1% in favor, 14.4% against, and 16.5% undecided) IPC members wanted to continue in future years.
+IEEE VIS 2025 in Vienna has come to a close and we—Niklas Elmqvist, Holger Theisel, and Melanie Tory, the 2025 Overall Papers Chairs (OPCs)—have reached the end of the road. Melanie will continue as OPC for VIS 2026 in Boston together with Tobias Isenberg (Inria) and Alex Endert (Georgia Tech), whereas Niklas and Holger (together with OPC assistant Petra Specht) can step down with what we think was a successful full paper program behind us. But before we do, we would like to report on the changes we made to the VIS review process this year.
+
+To help us understand the impact of these changes, we administered a survey to the IEEE VIS 2025 international program committee (IPC) asking about their experiences this year and their thoughts about the coming year. We can summarize the findings from 97 responses as follows:
+
+- The review load of approximately six papers (half as primary and half as secondary) was perceived to be just about right for most IPC members.
+- 61.9% of IPC members felt that keeping three reviewers (2 PC members and 1 external) was acceptable; 23.7% wanted to go back to four reviewers, and 14.4% were undecided.
+- Allowing for an additional week for submitting supplemental materials was almost uniformly seen as positive, with 83.5% in favor, 8.2% undecided, and 8.2% against.
+- The new student reviewer program was perceived as a positive initiative that most (69.1% in favor, 14.4% against, and 16.5% undecided) IPC members wanted to continue in future years.
 
 The student reviewer program is intended to increase the reviewer pool and combat reviewer fatigue in our community by allowing primary reviewers to invite a junior Ph.D. student as an "advisory" reviewer for every submission. The student learns the ropes under the mentorship of the primary while also providing another set of eyes on each paper. This also seems to have worked as intended. Except for some problems with implementation (some reviewers who were invited as regular reviewers nevertheless marked themselves as student reviewers) and miscommunication (there are already Ph.D. students who are experienced reviewers in our community), the program was very successful:
--	We received a total of 99 student reviews for 537 submitted papers, meaning that approximately 20% of primary reviewers invited a student reviewer for a paper.
--	All student reviewers were duly credited as full reviewers for the VIS 2026 full paper program (exposing otherwise hidden labor), with some of them even receiving review distinctions. 
--	The IPC's self-reported analysis of student reviews showed that they had no conclusive impact on review outcomes: only 5.6% of respondents felt the student review had a direct impact even if many positively remarked on the feedback student reviewers provided.
+
+- We received a total of 99 student reviews for 537 submitted papers, meaning that approximately 20% of primary reviewers invited a student reviewer for a paper.
+- All student reviewers were duly credited as full reviewers for the VIS 2025 full paper program (exposing otherwise hidden labor), with some of them even receiving review distinctions.
+- The IPC's self-reported analysis of student reviews showed that they had no conclusive impact on review outcomes: only 5.6% of respondents felt the student review had a direct impact even if many positively remarked on the feedback student reviewers provided.
 
 We are trying to improve some implementation details of the student reviewer program, but we are overall counting it as a success and are recommending that the VIS Steering Committee (VSC) continue it as an experimental program for at least three years before making a decision on its future.
 
-Another experimental program that we wanted to report on is the [VIS public peer review repository](https://osf.io/s9j5b/). Like the student reviewer program, this initiative was spearheaded by the VIS 2026 OPCs and approved by the VSC as an experiment for this year's conference. The goal is to improve transparency in the VIS review process by publishing anonymized peer reviews for accepted papers in a public repository. Only accepted papers where both the authors and all reviewers agree are included in the repository. For VIS 2026, a total of 16 papers fulfilled this criteria, yielding a total of 52 reviews (three reviews per paper resulting in 48 regular reviews, as well as—interestingly—4 student reviews). The repository has been publicly published on [OSF](https://osf.io/s9j5b/). We hope that future years will add to the corpus.
+Another experimental program that we wanted to report on is the [VIS public peer review repository](https://osf.io/s9j5b/). Like the student reviewer program, this initiative was spearheaded by the VIS 2025 OPCs and approved by the VSC as an experiment for this year's conference. The goal is to improve transparency in the VIS review process by publishing anonymized peer reviews for accepted papers in a public repository. Only accepted papers where both the authors and all reviewers agree are included in the repository. For VIS 2025, a total of 16 papers fulfilled this criteria, yielding a total of 52 reviews (three reviews per paper resulting in 48 regular reviews, as well as—interestingly—4 student reviews). The repository has been publicly published on [OSF](https://osf.io/s9j5b/). We hope that future years will add to the corpus.
 
 The public review program is perhaps a little more controversial than student reviewers. For example, in our survey, 16.7% of IPC members felt that the experiment should be stopped, whereas 65.6% felt it should continue, 12.5% wanted to relax the constraints so more reviews would be published, and 5.2% wanted to work towards open reviews. We think that there are clear benefits to making the VIS review process more transparent; for example, the four student reviews in the corpus give insight into that experimental program. Furthermore, the presence of public reviews can help new researchers learn the craft of peer review. However, several people have approached us with concerns; for example, that the review corpus could be used to fingerprint specific reviewers. Nevertheless, we count this year as a success and recommend that the VSC lets it continue for a full three years before being evaluated.
 
-And that's all, folks! It was our great honor to serve as your OPCs for the VIS 2026 conference. We could not have done it without the support of the 12 Area Papers Chairs (APCs), 205 IPC members, and many external and student reviewers from the community. And, as we said in the opening session, we had invaluable support by our indefatigable OPC assistant Petra Specht.
+And that's all, folks! It was our great honor to serve as your OPCs for the VIS 2025 conference. We could not have done it without the support of the 12 Area Papers Chairs (APCs), 205 IPC members, and many external and student reviewers from the community. And, as we said in the opening session, we had invaluable support by our indefatigable OPC assistant Petra Specht.
 
-Thank you all! VIS 2026 OPCs signing off.
+Thank you all! VIS 2025 OPCs signing off.


### PR DESCRIPTION
Closes #2406 

Fix: Correct year references in the VIS 2025 OPC blog post
Fixes incorrect year references in the November 2025 OPC blog post that mistakenly referred to the conference as "VIS 2026" instead of "VIS 2025".

**Changes**

- Updated title, author attribution, and description to reference VIS 2025
- Corrected few instances of "VIS 2026" to "VIS 2025" throughout the content
- Verified other blog files for similar year reference errors

**Files Changed**
- 2025-11-11-vis-2025-OPC-blog.md