### PR TITLE
fix: configure external links to open in new tab #2407

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,12 +6,24 @@ import tailwindcss from "@tailwindcss/vite";
 
 //https://docs.astro.build/en/guides/integrations-guide/sitemap/
 import sitemap from "@astrojs/sitemap";
+import rehypeExternalLinks from "rehype-external-links";
 
 // https://astro.build/config
 export default defineConfig({
   base: process.env.BASE_PATH || "/year/2026", //this can be accessed in tsx and astro as import.meta.env.BASE_URL
   integrations: [react(), sitemap()],
   site: process.env.SITE,
+  markdown: {
+    rehypePlugins: [
+      [
+        rehypeExternalLinks,
+        {
+          target: "_blank",
+          rel: ["noopener", "noreferrer"],
+        },
+      ],
+    ],
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "@types/react-dom": "^19.1.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
-        "prettier": "^3.7.4"
+        "prettier": "^3.7.4",
+        "rehype-external-links": "^3.0.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -3660,6 +3661,18 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -5464,6 +5477,24 @@
         "rehype-parse": "^9.0.0",
         "rehype-stringify": "^10.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@types/react-dom": "^19.1.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
-    "prettier": "^3.7.4"
+    "prettier": "^3.7.4",
+    "rehype-external-links": "^3.0.0"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/src/pages/blog/2025-05-22-vis-2025-ISOTYPES-blog.md
+++ b/src/pages/blog/2025-05-22-vis-2025-ISOTYPES-blog.md
@@ -13,7 +13,7 @@ date: 2025-05-22
 #### We could not have picked a more fitting year for IEEE VIS in Vienna!
 
 2025 is a special anniversary year celebrating the development of a visual language.
-One hundred years ago, **Otto Neurath** ([https://en.wikipedia.org/wiki/Otto_Neurath](https://en.wikipedia.org/wiki/Otto_Neurath){:target="\_blank"}) and his team in Vienna began developing what would become the **ISOTYPE** - short for the _International System of Typographic Picture Education_.
+One hundred years ago, **Otto Neurath** (https://en.wikipedia.org/wiki/Otto_Neurath) and his team in Vienna began developing what would become the **ISOTYPE** - short for the _International System of Typographic Picture Education_.
 What started in the context of post-World War I Austria as a practical method for educating the public about social and economic conditions has since become an important reference point in the history of visual communication.
 
 Otto Neurath (1882-1945) was an Austrian philosopher, sociologist, and political economist.
@@ -23,7 +23,7 @@ His main aim was to visually present statistical and social data using standardi
 He was not just interested in aesthetics; many of the people Otto Neurath hoped to reach had limited literacy or formal education.
 He intended the visual format to be more inclusive, immediate, and easily comparable across languages.
 
-ISOTYPES ([https://en.wikipedia.org/wiki/Isotype\_(picture_language)](<https://en.wikipedia.org/wiki/Isotype_(picture_language)>){:target="\_blank"}) consists of standardized and abstracted pictorial symbols representing social-scientific data.
+ISOTYPES (https://en.wikipedia.org/wiki/Isotype_(picture_language)) consists of standardized and abstracted pictorial symbols representing social-scientific data.
 They have specific guidelines for combining identical figures using serial repetition.
 For example, a single symbol (e.g., a figure representing 1,000 workers) would be repeated across the image rather than scaled proportionally, like pie charts or bar graphs.
 Otto Neurath worked closely with the German artist Gerd Arntz, who developed a coherent set of pictograms. Arntz's symbols were deliberately geometric and straightforward, designed to be easily reproduced and recognizable even at small sizes.


### PR DESCRIPTION
- Added rehype-external-links plugin to handle external links
- Configured all external links to open with target="_blank" and rel="noopener noreferrer"
- Fixed ISOTYPES blog post links that were displaying {:target="_blank"} syntax
- Simplified markdown syntax - external links now auto-open in new tabs