### PR TITLE
task: replaced Kathy Park with Coral Miller #2494

### DIFF
--- a/src/pages/info/committees/conference-committee.md
+++ b/src/pages/info/committees/conference-committee.md
@@ -144,4 +144,4 @@ active_nav: "Organization & History"
 | Aashish Panta                             | _University of Utah_                                         |
 |                                           |                                                              |
 | **IEEE**                                  |
-| Kathy Park                                | _IEEE Computer Society_                                      |
+| Coral Miller                              | _IEEE Computer Society_                                      |


### PR DESCRIPTION
Replaced Kathy Park with Coral Miller in the Organizing Committee