### PR TITLE
2501 redirect inactiveunreleased pages to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Make changes to the site:
 
 When you have made changes and would like to submit them, open a new pull request for the web chairs to review.
 
+## Inactive pages
+
+Pages that are not yet ready to publish can be listed under `inactivePathPrefixes` in `src/config/features.ts`; visitors (and search-engine crawlers) hitting those paths are redirected to the home page with a 302. Individual pages inside an inactive folder can be selectively re-enabled by adding their exact path to `activePathOverrides` in the same file.
+
 ## Automatic building
 
 After your PR is merged in, GitHub Actions will automatically build the staging site using the workflow file contained in [.github/workflows/staging.yml](/.github/workflows/staging.yml).

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,69 @@
+/**
+ * Feature flags for the IEEE VIS website
+ * Control which features are enabled/disabled
+ */
+
+export const features = {
+  /**
+   * Week of VIS feature
+   * Displays individual paper pages
+   */
+  weekOfVis: {
+    enabled: true, // Set to true to enable the feature
+    showcaseEnabled: false, // Enable the "Paper of the Week" showcase
+    dataSource:
+      "https://raw.githubusercontent.com/ieee-vgtc/vis-virtual-website/vis2025/sitedata/2025/paper_list.json",
+    // Alternatively, use local data:
+    // dataSource: '/data/papers/paper_list.json'
+  },
+
+  /**
+   * Blog feature
+   */
+  blog: {
+    enabled: true,
+  },
+
+  /**
+   * Registration
+   */
+  registration: {
+    enabled: false,
+  },
+
+  /**
+   * Explicit path overrides that are active even if their parent folder is
+   * listed in `inactivePathPrefixes`. These are checked first, so a match here
+   * always wins and the page is served normally.
+   *
+   * Use exact paths (no trailing slash), e.g.:
+   *   "/info/awards/best-paper-awards"
+   */
+  activePathOverrides: [
+    // "/info/awards/best-paper-awards",
+  ],
+
+  /**
+   * Inactive path prefixes (relative to the site base, without trailing slash).
+   * Any URL whose path starts with one of these prefixes will be redirected to
+   * the home page with a 302 (temporary) redirect until the content is ready.
+   * Individual pages within an inactive folder can be re-enabled via
+   * `activePathOverrides` above.
+   *
+   * Examples of matching paths for "/info/awards":
+   *   /info/awards
+   *   /info/awards/best-paper-awards
+   */
+  inactivePathPrefixes: [
+    "/info/awards",
+    "/info/invited-speakers",
+    "/info/local-events",
+    "/info/plenary",
+    "/info/presenter-information",
+    "/info/program",
+    "/info/registration-and-travel",
+    "/info/social-events",
+  ],
+} as const;
+
+export type Features = typeof features;

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -4,32 +4,14 @@
  */
 
 export const features = {
-  /**
-   * Week of VIS feature
-   * Displays individual paper pages
-   */
-  weekOfVis: {
-    enabled: true, // Set to true to enable the feature
-    showcaseEnabled: false, // Enable the "Paper of the Week" showcase
-    dataSource:
-      "https://raw.githubusercontent.com/ieee-vgtc/vis-virtual-website/vis2025/sitedata/2025/paper_list.json",
-    // Alternatively, use local data:
-    // dataSource: '/data/papers/paper_list.json'
-  },
-
-  /**
-   * Blog feature
-   */
-  blog: {
-    enabled: true,
-  },
-
-  /**
-   * Registration
-   */
-  registration: {
-    enabled: false,
-  },
+  // TODO: Week of VIS — future development
+  // weekOfVis: {
+  //   enabled: false,
+  //   showcaseEnabled: false,
+  //   // dataSource:
+  //   //   "https://raw.githubusercontent.com/ieee-vgtc/vis-virtual-website/vis2025/sitedata/2025/paper_list.json",
+  //   // dataSource: '/data/papers/paper_list.json'
+  // },
 
   /**
    * Explicit path overrides that are active even if their parent folder is

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,32 @@
 import type { MiddlewareHandler } from "astro";
+import { features } from "./config/features";
 
 //https://docs.astro.build/en/guides/middleware/
 export const onRequest: MiddlewareHandler = async (context, next) => {
+  // Strip the base path (e.g. "/year/2026") so denylist entries can be written
+  // as plain paths like "/info/awards" regardless of deployment base.
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const rawPath = context.url.pathname;
+  const pathWithoutBase = rawPath.startsWith(base)
+    ? rawPath.slice(base.length) || "/"
+    : rawPath;
+
+  const isOverridden = (
+    features.activePathOverrides as readonly string[]
+  ).includes(pathWithoutBase);
+
+  const isInactive =
+    !isOverridden &&
+    features.inactivePathPrefixes.some(
+      (prefix) =>
+        pathWithoutBase === prefix || pathWithoutBase.startsWith(prefix + "/"),
+    );
+
+  if (isInactive) {
+    // 302 = temporary redirect so search engines keep the URL for when it goes live
+    return context.redirect(import.meta.env.BASE_URL, 302);
+  }
+
   const response = await next();
 
   const isDev = import.meta.env.DEV;


### PR DESCRIPTION
**Redirect inactive/unreleased pages to home page**

Pages not yet ready to publish were still reachable via Google-indexed URLs, exposing incomplete content to visitors. This adds `inactivePathPrefixes` and `activePathOverrides` to features.ts and a middleware check that issues a 302 redirect to the home page for any inactive path, with folder-level blocking and per-page override support.

Also added about this in the README.

Closes #2501 