### PR TITLE
Make markdown tables scroll horizontally on mobile

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -131,9 +131,19 @@ p {
 }
 
 .content td,
-th {
+.content th {
   @apply px-4 py-3;
   overflow-wrap: break-word;
+}
+
+@media (max-width: 767px) {
+  .content table {
+    display: block;
+    overflow-x: auto;
+    table-layout: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: nowrap;
+  }
 }
 
 .content tbody tr:first-child {


### PR DESCRIPTION
Registration fee tables (and other markdown tables) used a fixed equal-width column layout that squeezed text into unreadable, letter-wrapped columns on narrow screens. Below 768px, tables now scroll horizontally with natural column widths instead. Also scopes the th padding rule to .content, matching the adjacent td rule. #2602