### PR TITLE
Enable VISKids page (supersedes #2600, #2601)

### DIFF
--- a/src/config/pages-allow-list.ts
+++ b/src/config/pages-allow-list.ts
@@ -55,7 +55,6 @@ export const features = {
     // "/info/program",
     // "/info/registration-and-travel",
     "/info/social-events",
-    "/info/inclusion/viskids",
     "/info/visinpractice/",
     // for working on the program pages, we want to disable the program page until it's ready
     "/program",

--- a/src/data/navigation.yml
+++ b/src/data/navigation.yml
@@ -275,7 +275,7 @@ menu:
                     description: "Childcare and activities open to everyone"
                     url: "/info/inclusion/viskids"
                     is_new: false
-                - text: "VISKids Childcare Grants"
+                  - text: "VISKids Childcare Grants"
                     description: "Supporting our VISKids and young families"
                     url: "/info/inclusion/viskids-child-care-grants"
                     is_new: false

--- a/src/data/navigation.yml
+++ b/src/data/navigation.yml
@@ -271,6 +271,15 @@ menu:
                     description: "Need-based scholarships for conference attendance"
                     url: "/info/inclusion/scholarship"
                     is_new: false
+                  - text: "VISKids"
+                    description: "Childcare and activities open to everyone"
+                    url: "/info/inclusion/viskids"
+                    is_new: false
+                - text: "VISKids Childcare Grants"
+                    description: "Supporting our VISKids and young families"
+                    url: "/info/inclusion/viskids-child-care-grants"
+                    is_new: false
+
           - heading: "Code of Conduct"
             heading_url: "/info/inclusion/code-of-conduct"
             description:

--- a/src/pages/info/inclusion/viskids.md
+++ b/src/pages/info/inclusion/viskids.md
@@ -5,25 +5,27 @@ active_nav: "Attend"
 contact: viskids@ieeevis.org
 ---
 
-The IEEE VIS conference is excited to support our VISKids and young families! This year, we will be providing professional child care in the VISKids room. The conference will not be providing direct grants to conference attendees as in years past.
+The IEEE VIS conference is excited to support our VISKids and young families! This year, VISKids will be organizing activities at the main conference location in Boston and will have a meeting room at the site.
+The activities and the room are *open to everyone,* not just awardees of the child care grant program.
+
+## VISKids Child Care Grants
+Grants of up to $500 per family are available for VIS attendees who are bringing small children to the conference or who incur extra expenses in leaving their children at home. The grants will be given as a reimbursement for expenses but attendees are responsible for making their own arrangements for child care. If requests exceed available funding, or if additional funding becomes available, preference will be given to students and early career attendees who are presenting at the conference.
+
+See the dedicated page for [child care grants](./viskids-child-care-grants) for details.
 
 ## VISKids Room
 
-Throughout the duration of the conference, VISKids will have a room for provided daycare, play, and personal considerations (e.g., nursing). The room will be staffed by a professional child care agency, hired by the VIS conference. The child care staff will be on hand to operate the VISKids room as a daycare. More information will be shared on the child care agency once the organizers have finalized a contract.
+Throughout the duration of the conference, VISKids will have a room for provided daycare, play, and personal considerations (e.g., nursing). Kids are very welcome and encouraged to come hang-out!
 
 ### VISKids Hello
 
-Prior to the conference, we will give you the opportunity to connect with other VISKids parents to meet and greet and share plans for adventures in Vienna.
+Prior to the conference, we will give you the opportunity to connect with other VISKids parents to meet and greet and share plans for adventures in Boston.
 
 ### Donate Toys to VISKids Room
 
 We ask any attendees, especially locals, to donate toys to the VISKids Room. Any toys you decide to bring to the VISKids Room will be donated after the conference to a local childrens organization. Please do not drop off toys at the VISKids Room that you hope to get back.
 
 If your child is attending VIS and wants to bring a toy, game, stuffed animal, etc. to the VISKids Room - please make sure they take it home with them at the end of each day. We don't want it to get lost in the collection of donated toys.
-
-## VISKids Child Care Grants
-
-We will not provide a childcare grants program as in years past. This year, the decision has been made to staff the VISKids Room with professional childcare. The VISKids Room will operate as a daycare to support families attending VIS.
 
 ## Contact
 
@@ -32,6 +34,11 @@ Please contact [VISKids@ieeevis.org](mailto:VISKids@ieeevis.org) with any questi
 ## Support VISKids
 
 If you are interested in being a VISKids supporter, please contact [supporters@ieeevis.org](mailto:supporters@ieeevis.org).
+
+**NOTE: The conference does not sanction or recommend
+specific childcare providers, and does not assume responsibility or
+liability for childcare services of any sort. It is the responsibility
+of the parent(s) to thoroughly investigate all childcare providers.**
 
 <!--
 

--- a/src/pages/info/inclusion/viskids.md
+++ b/src/pages/info/inclusion/viskids.md
@@ -6,12 +6,13 @@ contact: viskids@ieeevis.org
 ---
 
 The IEEE VIS conference is excited to support our VISKids and young families! This year, VISKids will be organizing activities at the main conference location in Boston and will have a meeting room at the site.
-The activities and the room are *open to everyone,* not just awardees of the child care grant program.
+The activities and the room are _open to everyone,_ not just awardees of the child care grant program.
 
 ## VISKids Child Care Grants
+
 Grants of up to $500 per family are available for VIS attendees who are bringing small children to the conference or who incur extra expenses in leaving their children at home. The grants will be given as a reimbursement for expenses but attendees are responsible for making their own arrangements for child care. If requests exceed available funding, or if additional funding becomes available, preference will be given to students and early career attendees who are presenting at the conference.
 
-See the dedicated page for [child care grants](./viskids-child-care-grants) for details.
+See the dedicated page for [child care grants](/year/2026/info/inclusion/viskids-child-care-grants) for details.
 
 ## VISKids Room
 


### PR DESCRIPTION
Combines the navigation.yml entries from #2600 and the viskids.md content update from #2601, plus the allow-list toggle and a link-format fix needed to make the page buildable. Please close #2600 and #2601 as superseded.