### PR TITLE
Add Bluesky discussion embed to paper pages (sortable by upvotes/recency)

### DIFF
--- a/src/components/Bluesky.tsx
+++ b/src/components/Bluesky.tsx
@@ -1,5 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { ReactNode } from "react";
+/**
+ * Read-only comments for any page, taken from the replies to one Bluesky post.
+ * Address it with the post's `at://` URI, or with the author's DID and the
+ * post's record key. The post itself is not shown, only the conversation under
+ * it, and replying happens on Bluesky.
+ *
+ * Pages that need the conference discussion service — threads addressed by
+ * paper id, comments from attendees without a Bluesky account — use
+ * `BlueskyDiscussion`. Both render the same cards.
+ */
+
+import { useCallback } from "react";
+import ReplyThread from "./bluesky/ReplyThread";
+import { fetchAppViewThread } from "./bluesky/direct";
+import type { ThreadResponse } from "./bluesky/types";
+import { usePolledThread } from "./bluesky/usePolledThread";
 
 const DEFAULT_MAX_DEPTH = 5;
 const DEFAULT_REFRESH_MS = 60_000;
@@ -7,545 +21,53 @@ const MAX_BACKOFF_MS = 30_000;
 
 interface BlueskyCommentsProps {
   did?: string;
+  /** The post's record key (the last segment of its `at://` URI). */
   postCid?: string;
   atUri?: string;
   maxDepth?: number;
+  /** An alternative AppView origin; the public one is the default. */
   apiBase?: string;
   refreshMs?: number;
   pauseWhenHidden?: boolean;
 }
 
-interface Author {
-  did?: string;
-  handle?: string;
-  displayName?: string;
-  avatar?: string;
-}
+export default function BlueskyComments({
+  did,
+  postCid,
+  atUri,
+  maxDepth = DEFAULT_MAX_DEPTH,
+  apiBase,
+  refreshMs = DEFAULT_REFRESH_MS,
+  pauseWhenHidden = true,
+}: BlueskyCommentsProps) {
+  const uri =
+    atUri ||
+    (did && postCid ? `at://${did}/app.bsky.feed.post/${postCid}` : "");
 
-interface Facet {
-  index?: {
-    byteStart?: number;
-    byteEnd?: number;
-  };
-  features?: Array<
-    | {
-        $type?: "app.bsky.richtext.facet#link";
-        uri?: string;
-      }
-    | {
-        $type?: "app.bsky.richtext.facet#mention";
-        did?: string;
-      }
-    | {
-        $type?: "app.bsky.richtext.facet#tag";
-        tag?: string;
-      }
-  >;
-}
-
-interface PostRecord {
-  text?: string;
-  facets?: Facet[];
-  createdAt?: string;
-}
-
-interface EmbedImage {
-  thumb?: string;
-  fullsize?: string;
-  alt?: string;
-}
-
-interface ExternalEmbed {
-  uri?: string;
-  title?: string;
-  description?: string;
-  thumb?: string;
-}
-
-interface RecordEmbedView {
-  uri?: string;
-  cid?: string;
-  author?: {
-    did?: string;
-    handle?: string;
-    displayName?: string;
-  };
-  value?: {
-    text?: string;
-  };
-}
-
-interface Embed {
-  $type?: string;
-  images?: EmbedImage[];
-  external?: ExternalEmbed;
-  record?: RecordEmbedView;
-  media?: Embed;
-}
-
-interface Post {
-  uri?: string;
-  cid?: string;
-  indexedAt?: string;
-  author?: Author;
-  record?: PostRecord;
-  embed?: Embed;
-  replyCount?: number;
-  likeCount?: number;
-  repostCount?: number;
-}
-
-interface Thread {
-  $type?: string;
-  post?: Post;
-  replies?: Thread[];
-}
-
-interface ThreadResponse {
-  thread?: Thread;
-}
-
-function formatRelativeTime(dateString?: string): string {
-  if (!dateString) {
-    return "";
-  }
-
-  const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) {
-    return "";
-  }
-
-  const deltaSeconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  const units = [
-    { label: "y", seconds: 31_536_000 },
-    { label: "mo", seconds: 2_592_000 },
-    { label: "d", seconds: 86_400 },
-    { label: "h", seconds: 3_600 },
-    { label: "m", seconds: 60 },
-  ];
-
-  for (const unit of units) {
-    if (deltaSeconds >= unit.seconds) {
-      return `${Math.floor(deltaSeconds / unit.seconds)}${unit.label}`;
-    }
-  }
-
-  return "now";
-}
-
-function profileHref(author?: Author): string {
-  const id = author?.handle || author?.did;
-  if (!id) {
-    return "https://bsky.app";
-  }
-  return `https://bsky.app/profile/${id}`;
-}
-
-function postHref(post?: Post): string {
-  const uri = post?.uri;
-  if (!uri) {
-    return "https://bsky.app";
-  }
-
-  const parts = uri.split("/");
-  const did = parts[2];
-  const rkey = parts[4];
-  if (!did || !rkey) {
-    return "https://bsky.app";
-  }
-
-  return `https://bsky.app/profile/${did}/post/${rkey}`;
-}
-
-function renderText(record?: PostRecord): ReactNode {
-  const text = record?.text || "";
-  return <p style={{ margin: "0.4rem 0", whiteSpace: "pre-wrap" }}>{text}</p>;
-}
-
-function renderEmbed(embed?: Embed): ReactNode {
-  if (!embed || !embed.$type) {
-    return null;
-  }
-
-  if (embed.$type === "app.bsky.embed.images#view") {
-    const images = embed.images || [];
-    if (images.length === 0) {
-      return null;
-    }
-
-    return (
-      <div
-        style={{
-          display: "grid",
-          gap: "0.5rem",
-          gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
-          marginTop: "0.5rem",
-        }}
-      >
-        {images.map((image, index) => (
-          <a
-            href={image.fullsize || image.thumb || "https://bsky.app"}
-            key={`${image.fullsize || image.thumb || "img"}-${index}`}
-            rel="noopener noreferrer"
-            style={{ display: "block" }}
-            target="_blank"
-          >
-            <img
-              alt={image.alt || "Bluesky embed image"}
-              src={image.thumb || image.fullsize}
-              style={{
-                width: "100%",
-                borderRadius: "0.5rem",
-                border: "1px solid #e5e7eb",
-              }}
-            />
-          </a>
-        ))}
-      </div>
-    );
-  }
-
-  if (embed.$type === "app.bsky.embed.external#view" && embed.external) {
-    const external = embed.external;
-    return (
-      <a
-        href={external.uri || "#"}
-        rel="noopener noreferrer"
-        style={{
-          display: "block",
-          border: "1px solid #e5e7eb",
-          borderRadius: "0.5rem",
-          marginTop: "0.5rem",
-          overflow: "hidden",
-          textDecoration: "none",
-          color: "inherit",
-        }}
-        target="_blank"
-      >
-        {external.thumb && (
-          <img
-            alt={external.title || "External preview"}
-            src={external.thumb}
-            style={{ width: "100%", maxHeight: "180px", objectFit: "cover" }}
-          />
-        )}
-        <div style={{ padding: "0.6rem" }}>
-          <strong style={{ display: "block", marginBottom: "0.2rem" }}>
-            {external.title || external.uri}
-          </strong>
-          {external.description && (
-            <small style={{ color: "#4b5563" }}>{external.description}</small>
-          )}
-        </div>
-      </a>
-    );
-  }
-
-  if (embed.$type === "app.bsky.embed.record#view" && embed.record) {
-    return (
-      <a
-        href={
-          embed.record.uri
-            ? postHref({ uri: embed.record.uri })
-            : "https://bsky.app"
-        }
-        rel="noopener noreferrer"
-        style={{
-          display: "block",
-          border: "1px solid #e5e7eb",
-          borderRadius: "0.5rem",
-          padding: "0.6rem",
-          marginTop: "0.5rem",
-          textDecoration: "none",
-          color: "inherit",
-        }}
-        target="_blank"
-      >
-        <strong style={{ display: "block", marginBottom: "0.2rem" }}>
-          Quoted post by @
-          {embed.record.author?.handle || embed.record.author?.did || "unknown"}
-        </strong>
-        <small>
-          {embed.record.value?.text || "Open quoted post on Bluesky"}
-        </small>
-      </a>
-    );
-  }
-
-  if (embed.$type === "app.bsky.embed.recordWithMedia#view") {
-    return (
-      <>
-        {renderEmbed(embed.media)}
-        {renderEmbed({
-          $type: "app.bsky.embed.record#view",
-          record: embed.record,
-        })}
-      </>
-    );
-  }
-
-  return (
-    <small style={{ color: "#6b7280", display: "block", marginTop: "0.5rem" }}>
-      This embed type ({embed.$type}) is not yet implemented.
-    </small>
-  );
-}
-
-function BlueskyReply({
-  thread,
-  depth,
-  maxDepth,
-}: {
-  thread: Thread;
-  depth: number;
-  maxDepth: number;
-}) {
-  if (!thread.post) {
-    return null;
-  }
-
-  const { post } = thread;
-  const authorName =
-    post.author?.displayName || post.author?.handle || "Unknown";
-
-  return (
-    <div
-      style={{
-        marginTop: "0.75rem",
-        marginLeft: depth * 12,
-        borderLeft: depth > 0 ? "2px solid #e5e7eb" : "none",
-        paddingLeft: depth > 0 ? "0.75rem" : 0,
-      }}
-    >
-      <article
-        style={{
-          border: "1px solid #e5e7eb",
-          borderRadius: "0.6rem",
-          padding: "0.75rem",
-          backgroundColor: "#fff",
-        }}
-      >
-        <header
-          style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}
-        >
-          {post.author?.avatar && (
-            <img
-              alt={`${authorName} avatar`}
-              src={post.author.avatar}
-              style={{
-                width: "36px",
-                height: "36px",
-                borderRadius: "9999px",
-                objectFit: "cover",
-                border: "1px solid #e5e7eb",
-              }}
-            />
-          )}
-          <div style={{ lineHeight: 1.2 }}>
-            <a
-              href={profileHref(post.author)}
-              rel="noopener noreferrer"
-              style={{
-                color: "inherit",
-                textDecoration: "none",
-                fontWeight: 600,
-              }}
-              target="_blank"
-            >
-              {authorName}
-            </a>
-            <div style={{ fontSize: "0.85rem", color: "#6b7280" }}>
-              @{post.author?.handle || post.author?.did || "unknown"}
-              {" · "}
-              <a
-                href={postHref(post)}
-                rel="noopener noreferrer"
-                style={{ color: "#2563eb", textDecoration: "none" }}
-                target="_blank"
-              >
-                {formatRelativeTime(post.record?.createdAt || post.indexedAt)}
-              </a>
-            </div>
-          </div>
-        </header>
-
-        {renderText(post.record)}
-        {renderEmbed(post.embed)}
-
-        <footer
-          style={{ fontSize: "0.82rem", color: "#6b7280", marginTop: "0.5rem" }}
-        >
-          {post.likeCount || 0} likes · {post.replyCount || 0} replies ·{" "}
-          {post.repostCount || 0} reposts
-        </footer>
-      </article>
-
-      {depth < maxDepth &&
-        thread.replies?.map((reply, index) => (
-          <BlueskyReply
-            depth={depth + 1}
-            key={reply.post?.uri || `${depth}-${index}`}
-            maxDepth={maxDepth}
-            thread={reply}
-          />
-        ))}
-
-      {depth >= maxDepth && (thread.replies?.length || 0) > 0 && (
-        <small
-          style={{ display: "block", marginTop: "0.4rem", color: "#6b7280" }}
-        >
-          View more replies on Bluesky.
-        </small>
-      )}
-    </div>
-  );
-}
-
-function buildAtUri({ atUri, did, postCid }: BlueskyCommentsProps): string {
-  if (atUri) {
-    return atUri;
-  }
-
-  if (!did || !postCid) {
-    return "";
-  }
-
-  return `at://${did}/app.bsky.feed.post/${postCid}`;
-}
-
-export default function BlueskyComments(props: BlueskyCommentsProps) {
-  const [thread, setThread] = useState<Thread | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const hasLoadedOnceRef = useRef(false);
-  const consecutiveFailuresRef = useRef(0);
-  const nextRequestAtRef = useRef(0);
-
-  const maxDepth = props.maxDepth ?? DEFAULT_MAX_DEPTH;
-  const apiBase = props.apiBase || "https://public.api.bsky.app";
-  const refreshMs = props.refreshMs ?? DEFAULT_REFRESH_MS;
-  const pauseWhenHidden = props.pauseWhenHidden ?? true;
-
-  const uri = useMemo(
-    () => buildAtUri(props),
-    [props.atUri, props.did, props.postCid],
-  );
-
-  useEffect(() => {
-    if (!uri) {
-      setLoading(false);
-      setError(
-        "Missing Bluesky post identifier. Provide atUri or did + postCid.",
-      );
-      return;
-    }
-
-    let disposed = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-    let currentController: AbortController | null = null;
-    let isFetching = false;
-
-    async function fetchThread() {
-      if (disposed || isFetching) {
-        return;
-      }
-      if (Date.now() < nextRequestAtRef.current) {
-        return;
-      }
-
-      isFetching = true;
-      const shouldShowLoading = !hasLoadedOnceRef.current;
-      if (shouldShowLoading) {
-        setLoading(true);
-      }
-      currentController = new AbortController();
-
-      try {
-        const endpoint = `${apiBase}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(uri)}&depth=100`;
-        const response = await fetch(endpoint, {
-          signal: currentController.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`Bluesky API returned ${response.status}`);
-        }
-
-        const data = (await response.json()) as ThreadResponse;
-        if (disposed) {
-          return;
-        }
-        setThread(data.thread || null);
-        hasLoadedOnceRef.current = true;
-        consecutiveFailuresRef.current = 0;
-        nextRequestAtRef.current = 0;
-        setError(null);
-      } catch (err) {
-        if ((err as Error).name === "AbortError") {
-          return;
-        }
-        if (disposed) {
-          return;
-        }
-
-        consecutiveFailuresRef.current += 1;
-        const backoffMs = Math.min(
-          refreshMs * 2 ** (consecutiveFailuresRef.current - 1),
-          MAX_BACKOFF_MS,
+  const load = useCallback(
+    async (signal: AbortSignal): Promise<ThreadResponse> => {
+      if (!uri) {
+        throw new Error(
+          "Missing Bluesky post identifier. Provide atUri or did + postCid.",
         );
-        nextRequestAtRef.current = Date.now() + backoffMs;
-
-        const message = (err as Error).message || "Could not load comments.";
-        if (!hasLoadedOnceRef.current) {
-          setError(message);
-        } else {
-          setError(
-            `Live update failed (${message}). Retrying in ${Math.ceil(backoffMs / 1000)}s.`,
-          );
-        }
-      } finally {
-        if (!disposed && shouldShowLoading) {
-          setLoading(false);
-        }
-        isFetching = false;
-        currentController = null;
       }
-    }
+      return fetchAppViewThread(uri, { base: apiBase, signal });
+    },
+    [apiBase, uri],
+  );
 
-    fetchThread();
+  const { data, loading, error } = usePolledThread({
+    load,
+    maxBackoffMs: MAX_BACKOFF_MS,
+    pauseWhenHidden,
+    refreshMs,
+  });
 
-    if (refreshMs > 0) {
-      intervalId = setInterval(() => {
-        if (pauseWhenHidden && document.visibilityState !== "visible") {
-          return;
-        }
-        fetchThread();
-      }, refreshMs);
-    }
-
-    function onVisibilityChange() {
-      if (!pauseWhenHidden || document.visibilityState !== "visible") {
-        return;
-      }
-      fetchThread();
-    }
-
-    if (pauseWhenHidden) {
-      document.addEventListener("visibilitychange", onVisibilityChange);
-    }
-
-    return () => {
-      disposed = true;
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-      if (pauseWhenHidden) {
-        document.removeEventListener("visibilitychange", onVisibilityChange);
-      }
-      currentController?.abort();
-    };
-  }, [apiBase, pauseWhenHidden, refreshMs, uri]);
-
-  const rootPost = thread?.post;
-  const replies = thread?.replies || [];
+  const root = data?.state === "open" ? data.post : undefined;
+  const replies = root?.replies || [];
+  // Deleted, blocked, or simply the wrong URI: say so rather than let it read
+  // as a post nobody has replied to.
+  const missing = data?.state === "unavailable";
 
   return (
     <section
@@ -558,14 +80,10 @@ export default function BlueskyComments(props: BlueskyCommentsProps) {
     >
       <h2 style={{ marginBottom: "0.5rem" }}>Comments</h2>
 
-      {rootPost && (
+      {root && (
         <p style={{ marginTop: 0, marginBottom: "1rem" }}>
           Join the conversation on{" "}
-          <a
-            href={postHref(rootPost)}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
+          <a href={root.bskyUrl} rel="noopener noreferrer" target="_blank">
             Bluesky
           </a>
           .
@@ -584,17 +102,23 @@ export default function BlueskyComments(props: BlueskyCommentsProps) {
           </p>
         ))}
 
-      {!loading && !error && replies.length === 0 && (
+      {!loading && !error && missing && (
+        <p style={{ color: "#b91c1c" }}>
+          This post is not available on Bluesky.
+        </p>
+      )}
+
+      {!loading && !error && !missing && replies.length === 0 && (
         <p>No replies yet. Be the first one on Bluesky.</p>
       )}
 
       {!loading &&
         replies.map((reply, index) => (
-          <BlueskyReply
+          <ReplyThread
             depth={0}
-            key={reply.post?.uri || `root-${index}`}
+            key={reply.uri || `root-${index}`}
             maxDepth={maxDepth}
-            thread={reply}
+            post={reply}
           />
         ))}
     </section>

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -24,16 +24,17 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, FormEvent, ReactNode } from "react";
+import type { CSSProperties, FormEvent } from "react";
 import PostCard from "./bluesky/PostCard";
-import ReplyThread from "./bluesky/ReplyThread";
+import type { PostLikeContext } from "./bluesky/PostCard";
+import ReplyList from "./bluesky/ReplyList";
 import SortToggle from "./bluesky/SortToggle";
 import { fetchAppViewThread } from "./bluesky/direct";
 import { formatOpensAt, likeCountOf } from "./bluesky/format";
 import { createServiceClient } from "./bluesky/service";
 import type {
-  LikesResponse,
   MeResponse,
+  MyLikesResponse,
   ServiceClient,
 } from "./bluesky/service";
 import type {
@@ -49,6 +50,9 @@ const DEFAULT_REFRESH_MS = 5_000;
 const MAX_DEPTH = 5;
 const COMMENT_LIMIT = 250; // graphemes; mirrors CONFERENCE.guestTextLimit
 const TOKEN_REFRESH_SKEW_MS = 60_000;
+// How much of the byline the "Comment as …" button shows before ellipsis, so a
+// long name cannot blow the button off its row.
+const BYLINE_LIMIT = 22;
 
 interface BlueskyDiscussionProps {
   /** `slots.slot_id` (e.g. "v-full-1234") or the paper UUID — the API takes both. */
@@ -93,13 +97,32 @@ function graphemeLength(text: string): number {
   return n;
 }
 
+/** Clip a byline to `BYLINE_LIMIT` code points, adding an ellipsis if cut. */
+function truncateByline(name: string): string {
+  const chars = Array.from(name);
+  return chars.length > BYLINE_LIMIT
+    ? `${chars.slice(0, BYLINE_LIMIT - 1).join("")}…`
+    : name;
+}
+
 /** Top-level ordering. "top" = most liked first (recency as tie-break);
- *  "newest" = most recent first. Nested replies stay chronological. */
-function sortReplies(replies: ShapedPost[], sort: ReplySort): ShapedPost[] {
+ *  "newest" = most recent first. Nested replies stay chronological.
+ *
+ *  The optimistic like `deltas` fold into the sort key as well as the count, so
+ *  a just-liked post rises immediately and holds that spot until the server
+ *  agrees (the delta is retired only once the server count passes its baseline);
+ *  without this a stale cached poll could shuffle it back for a beat. */
+function sortReplies(
+  replies: ShapedPost[],
+  sort: ReplySort,
+  deltas: Map<string, number>,
+): ShapedPost[] {
+  const likesOf = (post: ShapedPost) =>
+    likeCountOf(post) + (deltas.get(post.uri) ?? 0);
   const byRecency = (a: ShapedPost, b: ShapedPost) =>
     (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
   const byLikes = (a: ShapedPost, b: ShapedPost) =>
-    likeCountOf(b) - likeCountOf(a) || byRecency(a, b);
+    likesOf(b) - likesOf(a) || byRecency(a, b);
   return [...replies].sort(sort === "top" ? byLikes : byRecency);
 }
 
@@ -117,6 +140,54 @@ function collectUris(
     }
   }
   return into;
+}
+
+/** The server's merged like count for every post in a thread, keyed by URI. */
+function collectLikeCounts(
+  replies: ShapedPost[],
+  into = new Map<string, number>(),
+): Map<string, number> {
+  for (const reply of replies) {
+    if (reply.uri) {
+      into.set(reply.uri, likeCountOf(reply));
+    }
+    if (reply.replies?.length) {
+      collectLikeCounts(reply.replies, into);
+    }
+  }
+  return into;
+}
+
+/**
+ * The optimistic deltas still worth applying against the given server counts.
+ *
+ * A delta is dropped the moment the server count has moved past the baseline it
+ * was toggled against (in the delta's direction) — the server now reflects the
+ * change, so applying the delta too would double-count it. Doing this at read
+ * time (not only when pruning the stored state in an effect) closes the one
+ * render between fresh data arriving and that prune, where server + delta were
+ * briefly counted together — a transient that reordered the list and snapped it
+ * straight back. A post not yet in the thread (a just-posted comment) keeps its
+ * delta, as does one whose baseline we somehow lack.
+ */
+function reconcileDeltas(
+  deltas: Map<string, number>,
+  baselines: Map<string, number>,
+  serverCounts: Map<string, number>,
+): Map<string, number> {
+  const active = new Map<string, number>();
+  for (const [uri, delta] of deltas) {
+    const server = serverCounts.get(uri);
+    const baseline = baselines.get(uri);
+    if (server !== undefined && baseline !== undefined) {
+      const reflected = delta > 0 ? server > baseline : server < baseline;
+      if (reflected) {
+        continue;
+      }
+    }
+    active.set(uri, delta);
+  }
+  return active;
 }
 
 /**
@@ -274,7 +345,26 @@ export default function BlueskyDiscussion({
   const [submitting, setSubmitting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingReplies, setPendingReplies] = useState<ShapedPost[]>([]);
-  const [liked, setLiked] = useState(false);
+  // Which posts *this reader* has liked, and — while an optimistic toggle is in
+  // flight — a per-post adjustment laid over the server's total. The thread
+  // response is shared between readers (nginx-cached) and so cannot carry either.
+  const [likedUris, setLikedUris] = useState<Set<string>>(() => new Set());
+  const [likeDeltas, setLikeDeltas] = useState<Map<string, number>>(
+    () => new Map(),
+  );
+  // The server count each in-flight like was toggled against. A delta clears
+  // only once the server has moved past its baseline in the right direction, so
+  // a stale (cached) poll that predates the like cannot drop the count back.
+  const likeBaselinesRef = useRef<Map<string, number>>(new Map());
+  // The latest per-post server counts, so a fresh toggle can capture its
+  // baseline from what is currently on screen.
+  const serverCountsRef = useRef<Map<string, number>>(new Map());
+  // A live mirror of `likedUris` so the toggle can read the current state
+  // without being re-created on every like.
+  const likedUrisRef = useRef(likedUris);
+  useEffect(() => {
+    likedUrisRef.current = likedUris;
+  }, [likedUris]);
   const [refreshing, setRefreshing] = useState(false);
 
   const { hasToken, getToken } = useGuestToken(Boolean(paperId));
@@ -356,25 +446,25 @@ export default function BlueskyDiscussion({
   const interactive = data?.source === "service" && hasToken;
 
   /**
-   * Whether *this reader* has liked the paper. The thread response cannot carry
-   * it — that response is cached by nginx and shared between readers — so it
-   * comes from the per-user likes endpoint, which needs the bearer token.
+   * Which posts in this thread *this reader* has liked. The thread response
+   * cannot carry it — that response is cached by nginx and shared between
+   * readers — so it comes from the per-user endpoint, which needs the token.
    */
-  const syncLiked = useCallback(async () => {
+  const syncMyLikes = useCallback(async () => {
     const token = paperId ? await getToken() : null;
     if (!token || !paperId) {
       return;
     }
 
     try {
-      const response = await client.fetchLikes(paperId, token);
+      const response = await client.fetchMyLikes(paperId, token);
       if (!response.ok) {
         return;
       }
 
-      const likes = (await response.json()) as LikesResponse;
-      if (typeof likes.likedByMe === "boolean") {
-        setLiked(likes.likedByMe);
+      const likes = (await response.json()) as MyLikesResponse;
+      if (Array.isArray(likes.postUris)) {
+        setLikedUris(new Set(likes.postUris));
       }
     } catch {
       // A like-state miss is cosmetic; never surface it over the thread itself.
@@ -394,10 +484,42 @@ export default function BlueskyDiscussion({
       current.filter((reply) => !reply.uri || !known.has(reply.uri)),
     );
 
+    // Record the server's own counts, both so a new toggle can capture its
+    // baseline and so pending deltas can be reconciled against them.
+    const counts = data.thread.post
+      ? collectLikeCounts([data.thread.post])
+      : new Map<string, number>();
+    serverCountsRef.current = counts;
+
+    // Retire an optimistic delta only once the server count has actually moved
+    // past the baseline it was toggled against — a cached poll returning the
+    // pre-like count leaves the delta in place, so the count never drops back.
+    setLikeDeltas((current) => {
+      if (!current.size) {
+        return current;
+      }
+      let changed = false;
+      const next = new Map(current);
+      for (const [uri, delta] of current) {
+        const server = counts.get(uri);
+        if (server === undefined) {
+          continue; // not read back yet (e.g. a just-posted comment)
+        }
+        const baseline = likeBaselinesRef.current.get(uri) ?? server;
+        const reflected = delta > 0 ? server > baseline : server < baseline;
+        if (reflected) {
+          next.delete(uri);
+          likeBaselinesRef.current.delete(uri);
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+
     if (data.source === "service") {
-      void syncLiked();
+      void syncMyLikes();
     }
-  }, [data, syncLiked]);
+  }, [data, syncMyLikes]);
 
   const submitComment = useCallback(
     async (event: FormEvent) => {
@@ -464,6 +586,8 @@ export default function BlueskyDiscussion({
             guest: true,
             pseudonym: created.author || attribution || null,
             likeCount: 0,
+            guestLikeCount: 0,
+            totalLikeCount: 0,
             embedImages: [],
             replies: [],
           },
@@ -491,30 +615,77 @@ export default function BlueskyDiscussion({
     ],
   );
 
-  const toggleLike = useCallback(async () => {
-    const next = !liked;
-    setLiked(next); // optimistic
-    setActionError(null);
+  const toggleLike = useCallback(
+    async (postUri: string) => {
+      const next = !likedUrisRef.current.has(postUri);
 
-    try {
-      const token = paperId ? await getToken() : null;
-      if (!token || !paperId) {
-        setLiked(!next);
-        setActionError("Your session expired. Reload the page to like.");
-        return;
+      const applyOptimistic = (like: boolean) => {
+        setLikedUris((current) => {
+          const updated = new Set(current);
+          if (like) {
+            updated.add(postUri);
+          } else {
+            updated.delete(postUri);
+          }
+          return updated;
+        });
+      };
+      const bumpDelta = (by: number) => {
+        setLikeDeltas((current) => {
+          const updated = new Map(current);
+          const value = (updated.get(postUri) ?? 0) + by;
+          if (value === 0) {
+            // Back to the server's own count (e.g. a like then unlike, or a
+            // rollback): no adjustment to reconcile, so drop the baseline too.
+            updated.delete(postUri);
+            likeBaselinesRef.current.delete(postUri);
+          } else {
+            updated.set(postUri, value);
+            // Capture the count this like is measured against, once.
+            if (!likeBaselinesRef.current.has(postUri)) {
+              likeBaselinesRef.current.set(
+                postUri,
+                serverCountsRef.current.get(postUri) ?? 0,
+              );
+            }
+          }
+          return updated;
+        });
+      };
+
+      // Optimistic: flip the liked state and nudge the shown count now.
+      applyOptimistic(next);
+      bumpDelta(next ? 1 : -1);
+      setActionError(null);
+
+      const rollBack = () => {
+        applyOptimistic(!next);
+        bumpDelta(next ? -1 : 1);
+      };
+
+      try {
+        const token = paperId ? await getToken() : null;
+        if (!token || !paperId) {
+          rollBack();
+          setActionError("Your session expired. Reload the page to like.");
+          return;
+        }
+
+        const response = await client.setLike(paperId, token, postUri, next);
+        if (!response.ok && response.status !== 204) {
+          throw new Error(`The service returned ${response.status}.`);
+        }
+
+        await refresh(true);
+      } catch (err) {
+        rollBack();
+        setActionError(
+          (err as Error).message || "Your like could not be saved.",
+        );
       }
-
-      const response = await client.setLike(paperId, token, next);
-      if (!response.ok && response.status !== 204) {
-        throw new Error(`The service returned ${response.status}.`);
-      }
-
-      await refresh(true);
-    } catch (err) {
-      setLiked(!next); // roll back
-      setActionError((err as Error).message || "Your like could not be saved.");
-    }
-  }, [client, getToken, liked, paperId, refresh]);
+    },
+    [client, getToken, paperId, refresh],
+  );
 
   // ── render ──
 
@@ -548,53 +719,42 @@ export default function BlueskyDiscussion({
   }
 
   const root = thread?.state === "open" ? thread.post : undefined;
+  // Apply optimistic deltas only where the server has not already caught up, so
+  // the shown count and the sort order never briefly double-count a like being
+  // reconciled (see reconcileDeltas). Both the counts and the ordering read from
+  // the same reconciled map.
+  const serverCounts = root
+    ? collectLikeCounts([root])
+    : new Map<string, number>();
+  const activeDeltas = reconcileDeltas(
+    likeDeltas,
+    likeBaselinesRef.current,
+    serverCounts,
+  );
   // Pending (just-posted) replies stay pinned at the end regardless of sort so
   // the author always sees their own comment.
   const replies = [
-    ...sortReplies(root?.replies || [], sort),
+    ...sortReplies(root?.replies || [], sort, activeDeltas),
     ...pendingReplies,
   ];
   const remaining = COMMENT_LIMIT - graphemeLength(draft);
-  const rootLikes = root ? likeCountOf(root) : 0;
+  // The two possible bylines the submit button can show — the real name and the
+  // pseudonym — so it can reserve room for the wider and not resize (shoving the
+  // checkbox) when "Hide my name" flips between them. Until identity loads both
+  // are just "Comment".
+  const realNameByline = identity?.name || identity?.pseudonym || null;
+  const pseudonymByline = identity?.pseudonym || null;
+  const bylineLabel = (who: string | null) =>
+    who ? `Comment as ${truncateByline(who)}` : "Comment";
 
-  let rootFooter: ReactNode = null;
-  if (root) {
-    rootFooter = (
-      <>
-        {interactive && !hasBlueskyAccount ? (
-          <button
-            aria-pressed={liked}
-            onClick={toggleLike}
-            style={{
-              padding: "0.25rem 0.7rem",
-              borderRadius: "0.5rem",
-              border: "1px solid #e5e7eb",
-              backgroundColor: liked ? "#eff6ff" : "#fff",
-              color: liked ? "#2563eb" : "inherit",
-              cursor: "pointer",
-              fontSize: "0.82rem",
-            }}
-            type="button"
-          >
-            🍩 {rootLikes}
-          </button>
-        ) : (
-          <span>
-            {rootLikes} {rootLikes === 1 ? "like" : "likes"}
-          </span>
-        )}
-
-        <a
-          href={root.bskyUrl}
-          rel="noopener noreferrer"
-          style={{ color: "#2563eb", textDecoration: "none" }}
-          target="_blank"
-        >
-          View on Bluesky
-        </a>
-      </>
-    );
-  }
+  // The like control is the same on the root and every reply; the discussion
+  // owns the state so they all read and update one shared source.
+  const likeContext: PostLikeContext = {
+    canLike: interactive && !hasBlueskyAccount,
+    likedUris,
+    deltas: activeDeltas,
+    onToggle: toggleLike,
+  };
 
   return (
     <section
@@ -606,26 +766,38 @@ export default function BlueskyDiscussion({
       onPointerDown={markInteraction}
     >
       <h2 style={{ margin: "0 0 0.5rem" }}>Discussion</h2>
-      <style>{"@keyframes bsky-spin{to{transform:rotate(360deg)}}"}</style>
+      <style>
+        {"@keyframes bsky-spin{to{transform:rotate(360deg)}}" +
+          // Keyboard focus gets a clean inset ring in the callout blue, clipped
+          // to the card's rounded corners; a mouse click paints nothing (the
+          // default outline's bottom edge showed as a dashed line on the band).
+          ".bsky-callout:focus{outline:none}" +
+          ".bsky-callout:focus-visible{outline:2px solid #2563eb;outline-offset:-2px}"}
+      </style>
 
-      {root && <PostCard footer={rootFooter} post={root} variant="root" />}
+      {root && (
+        <div style={announcementCardStyle}>
+          <PostCard bare like={likeContext} post={root} variant="root" />
 
-      {root?.bskyUrl && (
-        <a
-          href={root.bskyUrl}
-          rel="noopener noreferrer"
-          style={calloutStyle}
-          target="_blank"
-        >
-          <span>
-            {hasBlueskyAccount
-              ? `You're signed in with @${blueskyHandle} — post and like directly on Bluesky`
-              : "Have a Bluesky account? View and join the conversation directly on Bluesky"}
-          </span>
-          <span aria-hidden="true" style={{ fontSize: "1.1rem" }}>
-            →
-          </span>
-        </a>
+          {root.bskyUrl && (
+            <a
+              className="bsky-callout"
+              href={root.bskyUrl}
+              rel="noopener noreferrer"
+              style={calloutFooterStyle}
+              target="_blank"
+            >
+              <span>
+                {hasBlueskyAccount
+                  ? `🦋 You're on Bluesky as @${blueskyHandle} — post and like directly there`
+                  : "🦋 View or join this discussion on Bluesky"}
+              </span>
+              <span aria-hidden="true" style={{ fontSize: "1.1rem" }}>
+                →
+              </span>
+            </a>
+          )}
+        </div>
       )}
 
       {interactive && !hasBlueskyAccount && (
@@ -658,10 +830,16 @@ export default function BlueskyDiscussion({
             value={draft}
           />
 
+          {/* One row: submit on the left, then the checkbox it drives right
+              beside it (with the "name is hidden" note tucked under the
+              checkbox), and the counter alone on the far right. */}
           <div
             style={{
               display: "flex",
-              alignItems: "center",
+              // Top-aligned: when the "name is hidden" note appears under the
+              // checkbox the column grows downward without re-centering (and so
+              // jumping) the button and checkbox.
+              alignItems: "flex-start",
               flexWrap: "wrap",
               gap: "0.5rem 0.75rem",
               marginTop: "0.5rem",
@@ -669,78 +847,87 @@ export default function BlueskyDiscussion({
               color: "#6b7280",
             }}
           >
-            <label
+            {/* The section is a polite live region, so the button's byline is
+                announced when "Hide my name" toggles it. */}
+            <button
+              disabled={submitting || !draft.trim() || remaining < 0}
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.35rem",
-                cursor: submitting ? "default" : "pointer",
+                padding: "0.4rem 0.9rem",
+                borderRadius: "0.5rem",
+                border: "1px solid #2563eb",
+                backgroundColor: "#2563eb",
+                color: "#fff",
+                cursor: "pointer",
+                fontSize: "0.9rem",
+                whiteSpace: "nowrap",
               }}
+              type="submit"
             >
-              <input
-                checked={anonymous}
-                disabled={submitting}
-                onChange={(event) => {
-                  markInteraction();
-                  setAnonymous(event.target.checked);
-                }}
-                type="checkbox"
-              />
-              Hide my name
-            </label>
-
-            {/* The section is already a polite live region, so a toggle of the
-                checkbox announces the new byline without one of its own. */}
-            <span style={{ color: "#374151" }}>
-              <span aria-hidden="true" style={{ color: "#9ca3af" }}>
-                ·{" "}
+              {/* Both bylines occupy one grid cell so the button reserves the
+                  wider width and does not resize (shoving the checkbox) when
+                  "Hide my name" flips which one shows; "Posting…" overlays while
+                  submitting. Only the active label is visible/announced. */}
+              <span style={{ display: "grid" }}>
+                <span
+                  style={{
+                    gridArea: "1 / 1",
+                    visibility: submitting || anonymous ? "hidden" : "visible",
+                  }}
+                >
+                  {bylineLabel(realNameByline)}
+                </span>
+                <span
+                  style={{
+                    gridArea: "1 / 1",
+                    visibility: submitting || !anonymous ? "hidden" : "visible",
+                  }}
+                >
+                  {bylineLabel(pseudonymByline)}
+                </span>
+                {submitting && <span style={{ gridArea: "1 / 1" }}>Posting…</span>}
               </span>
-              {attribution
-                ? `Posting as ${attribution}`
-                : "Posting under your pseudonym"}
-            </span>
+            </button>
 
             <div
-              style={{
-                marginLeft: "auto",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.75rem",
-              }}
+              style={{ display: "flex", flexDirection: "column", gap: "0.15rem" }}
             >
-              <small style={{ color: remaining < 0 ? "#b91c1c" : "#6b7280" }}>
-                {remaining}
-              </small>
-              <button
-                disabled={submitting || !draft.trim() || remaining < 0}
+              <label
                 style={{
-                  padding: "0.4rem 0.9rem",
-                  borderRadius: "0.5rem",
-                  border: "1px solid #2563eb",
-                  backgroundColor: "#2563eb",
-                  color: "#fff",
-                  cursor: "pointer",
-                  fontSize: "0.9rem",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.35rem",
+                  cursor: submitting ? "default" : "pointer",
                 }}
-                type="submit"
               >
-                {submitting ? "Posting…" : "Comment"}
-              </button>
-            </div>
-          </div>
+                <input
+                  checked={anonymous}
+                  disabled={submitting}
+                  onChange={(event) => {
+                    markInteraction();
+                    setAnonymous(event.target.checked);
+                  }}
+                  type="checkbox"
+                />
+                Hide my name
+              </label>
 
-          {anonymous && (
+              {anonymous && (
+                <small style={{ fontSize: "0.8rem", color: "#6b7280" }}>
+                  Your name is hidden from readers, not from conference
+                  organizers.
+                </small>
+              )}
+            </div>
+
             <small
               style={{
-                display: "block",
-                marginTop: "0.4rem",
-                fontSize: "0.8rem",
-                color: "#6b7280",
+                marginLeft: "auto",
+                color: remaining < 0 ? "#b91c1c" : "#6b7280",
               }}
             >
-              Your name is hidden from readers, not from conference organizers.
+              {remaining}
             </small>
-          )}
+          </div>
         </form>
       )}
 
@@ -831,34 +1018,38 @@ export default function BlueskyDiscussion({
         </div>
       </div>
 
-      {replies.map((reply, index) => (
-        <ReplyThread
-          depth={0}
-          key={reply.uri || `root-${index}`}
-          maxDepth={maxDepth}
-          post={reply}
-        />
-      ))}
+      <ReplyList like={likeContext} maxDepth={maxDepth} replies={replies} />
     </section>
   );
 }
 
 const sectionStyle: CSSProperties = {
-  marginTop: "2rem",
-  borderTop: "1px solid #d1d5db",
-  paddingTop: "1.2rem",
+  marginTop: "2.5rem",
 };
 
-/** The prominent "join on Bluesky" callout above the composer. */
-const calloutStyle: CSSProperties = {
+/**
+ * The announcement and the Bluesky callout share one bordered box; `overflow`
+ * clips the callout's shaded footer band to the rounded bottom corners.
+ */
+const announcementCardStyle: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: "0.6rem",
+  overflow: "hidden",
+  backgroundColor: "#f9fafb",
+  marginBottom: "0.75rem",
+};
+
+/** The "join on Bluesky" callout, as a shaded footer band of the card above. */
+const calloutFooterStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
   gap: "0.75rem",
-  margin: "1rem 0 0.75rem",
   padding: "0.7rem 0.9rem",
-  borderRadius: "0.6rem",
-  border: "1px solid #bfdbfe",
+  borderTop: "1px solid #bfdbfe",
+  // The site's prose links carry a dashed border-bottom (.content a); this is a
+  // full-width link, so without this it draws a dashed rule across the band.
+  borderBottom: "none",
   backgroundColor: "#eff6ff",
   color: "#1e3a8a",
   fontWeight: 600,

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -1,0 +1,699 @@
+/**
+ * The Bluesky discussion of a page's post: the announcement itself, its reply
+ * thread, and — where the reader is allowed — a comment box and a like button.
+ *
+ * It reads from either of two sources, which deliver the same shaped thread
+ * (`bluesky/types.ts`):
+ *
+ *   - `atUri` reads the thread straight from the public Bluesky AppView. This
+ *     is what pages use once the real post URIs are known and baked in.
+ *   - `paperId` reads it from the conference discussion service, which
+ *     addresses threads by the paper's stable id, reaches readers behind
+ *     networks that cannot see Bluesky, and is the only source that accepts
+ *     guest writes.
+ *
+ * Given both, the AppView is tried first and the service is the fallback.
+ * Commenting and liking appear only when the thread came from the service and
+ * the reader's site session yields a token; everything else is read-only.
+ *
+ * A comment carries the attendee's real name unless they tick "Hide my name",
+ * which swaps it for their stable pseudonym. Such a post is unnamed rather than
+ * untraceable — organizers can still tell who wrote it — so the label says what
+ * it does instead of calling the post anonymous, and the hint beside it spells
+ * out the difference.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties, FormEvent, ReactNode } from "react";
+import PostCard from "./bluesky/PostCard";
+import ReplyThread from "./bluesky/ReplyThread";
+import SortToggle from "./bluesky/SortToggle";
+import { fetchAppViewThread } from "./bluesky/direct";
+import { formatOpensAt, likeCountOf } from "./bluesky/format";
+import { createServiceClient } from "./bluesky/service";
+import type {
+  LikesResponse,
+  MeResponse,
+  ServiceClient,
+} from "./bluesky/service";
+import type {
+  ReplySort,
+  ShapedPost,
+  ThreadResponse,
+  ThreadSource,
+} from "./bluesky/types";
+import { usePolledThread } from "./bluesky/usePolledThread";
+
+const DEFAULT_API_BASES = ["https://bsky.tech.ieeevis.org"];
+const DEFAULT_REFRESH_MS = 30_000;
+const MAX_DEPTH = 5;
+const COMMENT_LIMIT = 250; // graphemes; mirrors CONFERENCE.guestTextLimit
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+
+interface BlueskyDiscussionProps {
+  /** `slots.slot_id` (e.g. "v-full-1234") or the paper UUID — the API takes both. */
+  paperId?: string;
+  /** `at://did/app.bsky.feed.post/rkey` of the post the thread hangs off. */
+  atUri?: string;
+  /**
+   * Service origins in priority order; the next one is tried when a request
+   * fails to reach the current one.
+   */
+  apiBases?: string[];
+  refreshMs?: number;
+  maxDepth?: number;
+  /** Initial order of top-level replies; the reader can toggle. */
+  defaultSort?: ReplySort;
+}
+
+interface LoadedThread {
+  source: ThreadSource;
+  thread: ThreadResponse;
+}
+
+interface GuestToken {
+  token: string;
+  expiresAt: number;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Count the way the API does, so the counter and the 400 agree. */
+function graphemeLength(text: string): number {
+  const Segmenter = (Intl as { Segmenter?: typeof Intl.Segmenter }).Segmenter;
+  if (!Segmenter) {
+    return [...text].length;
+  }
+  let n = 0;
+  for (const _ of new Segmenter("en", { granularity: "grapheme" }).segment(
+    text,
+  )) {
+    n++;
+  }
+  return n;
+}
+
+/** Top-level ordering. "top" = most liked first (recency as tie-break);
+ *  "newest" = most recent first. Nested replies stay chronological. */
+function sortReplies(replies: ShapedPost[], sort: ReplySort): ShapedPost[] {
+  const byRecency = (a: ShapedPost, b: ShapedPost) =>
+    (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+  const byLikes = (a: ShapedPost, b: ShapedPost) =>
+    likeCountOf(b) - likeCountOf(a) || byRecency(a, b);
+  return [...replies].sort(sort === "top" ? byLikes : byRecency);
+}
+
+/** Every reply URI in a thread, at any depth. */
+function collectUris(
+  replies: ShapedPost[],
+  into = new Set<string>(),
+): Set<string> {
+  for (const reply of replies) {
+    if (reply.uri) {
+      into.add(reply.uri);
+    }
+    if (reply.replies?.length) {
+      collectUris(reply.replies, into);
+    }
+  }
+  return into;
+}
+
+/**
+ * Mint a short-lived token from the site's own session. Paper pages are behind
+ * `isProtectedPath`, so a reader who got this far normally has a session; a 401
+ * simply means "no guest UI" and is not an error worth showing.
+ */
+function useGuestToken(enabled: boolean) {
+  const tokenRef = useRef<GuestToken | null>(null);
+  const [hasToken, setHasToken] = useState(false);
+
+  const getToken = useCallback(async (): Promise<string | null> => {
+    if (!enabled) {
+      return null;
+    }
+
+    const cached = tokenRef.current;
+    if (cached && cached.expiresAt - TOKEN_REFRESH_SKEW_MS > Date.now()) {
+      return cached.token;
+    }
+
+    try {
+      const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+      const response = await fetch(`${base}/auth/token`, {
+        credentials: "same-origin",
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        tokenRef.current = null;
+        setHasToken(false);
+        return null;
+      }
+
+      const data = (await response.json()) as {
+        token?: string;
+        expiresAt?: string;
+      };
+      if (!data.token) {
+        setHasToken(false);
+        return null;
+      }
+
+      tokenRef.current = {
+        token: data.token,
+        expiresAt: data.expiresAt
+          ? Date.parse(data.expiresAt)
+          : Date.now() + 600_000,
+      };
+      setHasToken(true);
+      return data.token;
+    } catch {
+      setHasToken(false);
+      return null;
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void getToken();
+  }, [getToken]);
+
+  return { hasToken, getToken };
+}
+
+/**
+ * Who the reader will be credited as, read once the token exists. A miss leaves
+ * this null, and the form falls back to promising only the pseudonym — the
+ * weaker claim of the two, and so the safe one to make when we cannot check.
+ */
+function useIdentity(
+  client: ServiceClient,
+  getToken: () => Promise<string | null>,
+  enabled: boolean,
+) {
+  const [identity, setIdentity] = useState<MeResponse | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const token = await getToken();
+        if (!token) {
+          return;
+        }
+
+        const response = await client.fetchMe(token, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          return;
+        }
+
+        const me = (await response.json()) as Partial<MeResponse>;
+        if (typeof me.pseudonym === "string") {
+          setIdentity({ name: me.name ?? null, pseudonym: me.pseudonym });
+        }
+      } catch {
+        // Cosmetic: the checkbox still works, the preview is just vaguer.
+      }
+    })();
+
+    return () => controller.abort();
+  }, [client, enabled, getToken]);
+
+  return identity;
+}
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+export default function BlueskyDiscussion({
+  paperId,
+  atUri,
+  apiBases = DEFAULT_API_BASES,
+  refreshMs = DEFAULT_REFRESH_MS,
+  maxDepth = MAX_DEPTH,
+  defaultSort = "top",
+}: BlueskyDiscussionProps) {
+  const [sort, setSort] = useState<ReplySort>(defaultSort);
+  const [draft, setDraft] = useState("");
+  const [anonymous, setAnonymous] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingReplies, setPendingReplies] = useState<ShapedPost[]>([]);
+  const [liked, setLiked] = useState(false);
+
+  const { hasToken, getToken } = useGuestToken(Boolean(paperId));
+
+  // Callers pass an inline array literal, so depend on its contents rather than
+  // its identity — otherwise every render would build a new client and restart
+  // the polling effect.
+  const basesKey = apiBases.join(",");
+  const client = useMemo(
+    () => createServiceClient(basesKey.split(",")),
+    [basesKey],
+  );
+
+  const identity = useIdentity(client, getToken, hasToken);
+  /** What the service will put in front of the post, as best we can predict. */
+  const attribution = anonymous
+    ? identity?.pseudonym
+    : identity?.name || identity?.pseudonym;
+
+  const load = useCallback(
+    async (signal: AbortSignal, fresh: boolean): Promise<LoadedThread> => {
+      if (atUri) {
+        try {
+          const thread = await fetchAppViewThread(atUri, { signal });
+          // Unreachable from here (blocked network) or not there at all: with a
+          // paper id the service can still answer, so let it try.
+          if (thread.state !== "unavailable" || !paperId) {
+            return { source: "direct", thread };
+          }
+        } catch (err) {
+          if ((err as Error).name === "AbortError" || !paperId) {
+            throw err;
+          }
+        }
+      }
+
+      if (!paperId) {
+        throw new Error("No Bluesky post URI or paper id was given.");
+      }
+
+      return {
+        source: "service",
+        thread: await client.fetchThread(paperId, { signal, fresh }),
+      };
+    },
+    [atUri, client, paperId],
+  );
+
+  const { data, loading, error, refresh } = usePolledThread({
+    load,
+    refreshMs,
+  });
+
+  const thread = data?.thread;
+  /** Guest writes are bridged by the service; the AppView is read-only here. */
+  const interactive = data?.source === "service" && hasToken;
+
+  /**
+   * Whether *this reader* has liked the paper. The thread response cannot carry
+   * it — that response is cached by nginx and shared between readers — so it
+   * comes from the per-user likes endpoint, which needs the bearer token.
+   */
+  const syncLiked = useCallback(async () => {
+    const token = paperId ? await getToken() : null;
+    if (!token || !paperId) {
+      return;
+    }
+
+    try {
+      const response = await client.fetchLikes(paperId, token);
+      if (!response.ok) {
+        return;
+      }
+
+      const likes = (await response.json()) as LikesResponse;
+      if (typeof likes.likedByMe === "boolean") {
+        setLiked(likes.likedByMe);
+      }
+    } catch {
+      // A like-state miss is cosmetic; never surface it over the thread itself.
+    }
+  }, [client, getToken, paperId]);
+
+  useEffect(() => {
+    if (!data || data.thread.state !== "open") {
+      return;
+    }
+
+    // Drop optimistic replies only once they appear in the real thread — a
+    // cached response may not include them yet, and clearing on every poll
+    // would make a just-posted comment flicker out and back.
+    const known = collectUris(data.thread.post?.replies || []);
+    setPendingReplies((current) =>
+      current.filter((reply) => !reply.uri || !known.has(reply.uri)),
+    );
+
+    if (data.source === "service") {
+      void syncLiked();
+    }
+  }, [data, syncLiked]);
+
+  const submitComment = useCallback(
+    async (event: FormEvent) => {
+      const text = draft.trim();
+      event.preventDefault();
+      if (!text || submitting || !paperId) {
+        return;
+      }
+      if (graphemeLength(text) > COMMENT_LIMIT) {
+        setActionError(`Comments are limited to ${COMMENT_LIMIT} characters.`);
+        return;
+      }
+
+      setSubmitting(true);
+      setActionError(null);
+
+      try {
+        const token = await getToken();
+        if (!token) {
+          setActionError("Your session expired. Reload the page to comment.");
+          return;
+        }
+
+        const response = await client.postComment(
+          paperId,
+          token,
+          text,
+          anonymous,
+        );
+
+        if (response.status === 429) {
+          const retryAfter = response.headers.get("retry-after");
+          setActionError(
+            retryAfter
+              ? `You are commenting too quickly. Try again in ${retryAfter}s.`
+              : "You are commenting too quickly. Try again shortly.",
+          );
+          return;
+        }
+        if (response.status === 409) {
+          setActionError("This discussion is not open yet.");
+          return;
+        }
+        if (!response.ok) {
+          throw new Error(`The service returned ${response.status}.`);
+        }
+
+        const created = (await response.json()) as {
+          uri?: string;
+          author?: string;
+        };
+
+        // Show it immediately; the next refetch replaces it with the real post.
+        // The service credits the post by prefixing its text, which the local
+        // draft has none of, so the name it reports back rides in `pseudonym` —
+        // where `displayPost` looks first — for these few seconds.
+        setPendingReplies((current) => [
+          ...current,
+          {
+            uri: created.uri || `pending-${Date.now()}`,
+            author: { displayName: null, avatar: null },
+            text,
+            createdAt: new Date().toISOString(),
+            guest: true,
+            pseudonym: created.author || attribution || null,
+            likeCount: 0,
+            embedImages: [],
+            replies: [],
+          },
+        ]);
+        setDraft("");
+
+        await refresh(true);
+      } catch (err) {
+        setActionError(
+          (err as Error).message || "Your comment could not be posted.",
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [
+      anonymous,
+      attribution,
+      client,
+      draft,
+      getToken,
+      paperId,
+      refresh,
+      submitting,
+    ],
+  );
+
+  const toggleLike = useCallback(async () => {
+    const next = !liked;
+    setLiked(next); // optimistic
+    setActionError(null);
+
+    try {
+      const token = paperId ? await getToken() : null;
+      if (!token || !paperId) {
+        setLiked(!next);
+        setActionError("Your session expired. Reload the page to like.");
+        return;
+      }
+
+      const response = await client.setLike(paperId, token, next);
+      if (!response.ok && response.status !== 204) {
+        throw new Error(`The service returned ${response.status}.`);
+      }
+
+      await refresh(true);
+    } catch (err) {
+      setLiked(!next); // roll back
+      setActionError((err as Error).message || "Your like could not be saved.");
+    }
+  }, [client, getToken, liked, paperId, refresh]);
+
+  // ── render ──
+
+  // Nothing is mapped for this paper (no session, withdrawn, or not in the
+  // program). Render nothing at all rather than an empty "Discussion" heading.
+  if (thread?.state === "unavailable") {
+    return null;
+  }
+
+  if (loading && !thread) {
+    return (
+      <section style={sectionStyle} aria-live="polite">
+        <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
+        <p style={{ color: "#6b7280" }}>Loading the discussion…</p>
+      </section>
+    );
+  }
+
+  if (thread?.state === "not_open") {
+    const opensAt = formatOpensAt(thread.opensAt);
+    return (
+      <section style={sectionStyle} aria-live="polite">
+        <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
+        <p style={{ color: "#6b7280", margin: 0 }}>
+          {opensAt
+            ? `The discussion for this paper opens shortly before its session, on ${opensAt}.`
+            : "The discussion for this paper opens shortly before its session."}
+        </p>
+      </section>
+    );
+  }
+
+  const root = thread?.state === "open" ? thread.post : undefined;
+  // Pending (just-posted) replies stay pinned at the end regardless of sort so
+  // the author always sees their own comment.
+  const replies = [
+    ...sortReplies(root?.replies || [], sort),
+    ...pendingReplies,
+  ];
+  const remaining = COMMENT_LIMIT - graphemeLength(draft);
+  const rootLikes = root ? likeCountOf(root) : 0;
+
+  let rootFooter: ReactNode = null;
+  if (root) {
+    rootFooter = (
+      <>
+        {interactive ? (
+          <button
+            aria-pressed={liked}
+            onClick={toggleLike}
+            style={{
+              padding: "0.25rem 0.7rem",
+              borderRadius: "0.5rem",
+              border: "1px solid #e5e7eb",
+              backgroundColor: liked ? "#eff6ff" : "#fff",
+              color: liked ? "#2563eb" : "inherit",
+              cursor: "pointer",
+              fontSize: "0.82rem",
+            }}
+            type="button"
+          >
+            {liked ? "♥" : "♡"} {rootLikes}
+          </button>
+        ) : (
+          <span>
+            {rootLikes} {rootLikes === 1 ? "like" : "likes"}
+          </span>
+        )}
+
+        <a
+          href={root.bskyUrl}
+          rel="noopener noreferrer"
+          style={{ color: "#2563eb", textDecoration: "none" }}
+          target="_blank"
+        >
+          View on Bluesky
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <section style={sectionStyle} aria-live="polite">
+      <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
+
+      {root && <PostCard footer={rootFooter} post={root} variant="root" />}
+
+      {interactive && (
+        <form onSubmit={submitComment} style={{ margin: "1rem 0" }}>
+          <label
+            htmlFor={`bsky-comment-${paperId}`}
+            style={{ display: "none" }}
+          >
+            Add a comment
+          </label>
+          <textarea
+            disabled={submitting}
+            id={`bsky-comment-${paperId}`}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="Add a comment"
+            rows={3}
+            style={{
+              width: "100%",
+              padding: "0.6rem",
+              border: "1px solid #e5e7eb",
+              borderRadius: "0.5rem",
+              fontFamily: "inherit",
+              fontSize: "0.95rem",
+              resize: "vertical",
+            }}
+            value={draft}
+          />
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: "0.5rem",
+              marginTop: "0.5rem",
+              fontSize: "0.85rem",
+              color: "#6b7280",
+            }}
+          >
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.35rem",
+                cursor: submitting ? "default" : "pointer",
+              }}
+            >
+              <input
+                checked={anonymous}
+                disabled={submitting}
+                onChange={(event) => setAnonymous(event.target.checked)}
+                type="checkbox"
+              />
+              Hide my name
+            </label>
+
+            {/* The section is already a polite live region, so a toggle of the
+                checkbox announces the new byline without one of its own. */}
+            <span style={{ color: "#374151" }}>
+              <span aria-hidden="true" style={{ color: "#9ca3af" }}>
+                ·{" "}
+              </span>
+              {attribution
+                ? `Posting as ${attribution}`
+                : "Posting under your pseudonym"}
+            </span>
+          </div>
+
+          <small
+            style={{
+              display: "block",
+              marginTop: "0.3rem",
+              fontSize: "0.8rem",
+              color: "#6b7280",
+            }}
+          >
+            Your name is hidden from readers, not from conference organizers.
+          </small>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.75rem",
+              marginTop: "0.6rem",
+            }}
+          >
+            <button
+              disabled={submitting || !draft.trim() || remaining < 0}
+              style={{
+                padding: "0.4rem 0.9rem",
+                borderRadius: "0.5rem",
+                border: "1px solid #2563eb",
+                backgroundColor: "#2563eb",
+                color: "#fff",
+                cursor: "pointer",
+                fontSize: "0.9rem",
+              }}
+              type="submit"
+            >
+              {submitting ? "Posting…" : "Comment"}
+            </button>
+
+            <small
+              style={{
+                marginLeft: "auto",
+                color: remaining < 0 ? "#b91c1c" : "#6b7280",
+              }}
+            >
+              {remaining}
+            </small>
+          </div>
+        </form>
+      )}
+
+      {actionError && (
+        <p style={{ color: "#b91c1c", marginTop: 0 }}>{actionError}</p>
+      )}
+
+      {error && (
+        <p style={{ color: replies.length > 0 ? "#92400e" : "#b91c1c" }}>
+          {replies.length > 0
+            ? error
+            : `Could not load the discussion: ${error}`}
+        </p>
+      )}
+
+      {!error && replies.length === 0 && (
+        <p style={{ color: "#6b7280" }}>
+          No comments yet.{interactive ? " Start the conversation." : ""}
+        </p>
+      )}
+
+      {replies.length > 1 && <SortToggle onChange={setSort} sort={sort} />}
+
+      {replies.map((reply, index) => (
+        <ReplyThread
+          depth={0}
+          key={reply.uri || `root-${index}`}
+          maxDepth={maxDepth}
+          post={reply}
+        />
+      ))}
+    </section>
+  );
+}
+
+const sectionStyle: CSSProperties = {
+  marginTop: "2rem",
+  borderTop: "1px solid #d1d5db",
+  paddingTop: "1.2rem",
+};

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -241,7 +241,11 @@ function useIdentity(
 
         const me = (await response.json()) as Partial<MeResponse>;
         if (typeof me.pseudonym === "string") {
-          setIdentity({ name: me.name ?? null, pseudonym: me.pseudonym });
+          setIdentity({
+            name: me.name ?? null,
+            pseudonym: me.pseudonym,
+            bluesky: typeof me.bluesky === "string" ? me.bluesky : null,
+          });
         }
       } catch {
         // Cosmetic: the checkbox still works, the preview is just vaguer.
@@ -289,6 +293,10 @@ export default function BlueskyDiscussion({
   const attribution = anonymous
     ? identity?.pseudonym
     : identity?.name || identity?.pseudonym;
+  // A reader who has linked a Bluesky account can post and like there directly,
+  // so we hide the guest composer for them and point them at the thread instead.
+  const blueskyHandle = identity?.bluesky?.trim() || null;
+  const hasBlueskyAccount = Boolean(blueskyHandle);
 
   const load = useCallback(
     async (signal: AbortSignal, fresh: boolean): Promise<LoadedThread> => {
@@ -553,7 +561,7 @@ export default function BlueskyDiscussion({
   if (root) {
     rootFooter = (
       <>
-        {interactive ? (
+        {interactive && !hasBlueskyAccount ? (
           <button
             aria-pressed={liked}
             onClick={toggleLike}
@@ -568,7 +576,7 @@ export default function BlueskyDiscussion({
             }}
             type="button"
           >
-            {liked ? "♥" : "♡"} {rootLikes}
+            🍩 {rootLikes}
           </button>
         ) : (
           <span>
@@ -597,16 +605,181 @@ export default function BlueskyDiscussion({
       // resets the polling cadence to the base interval.
       onPointerDown={markInteraction}
     >
+      <h2 style={{ margin: "0 0 0.5rem" }}>Discussion</h2>
+      <style>{"@keyframes bsky-spin{to{transform:rotate(360deg)}}"}</style>
+
+      {root && <PostCard footer={rootFooter} post={root} variant="root" />}
+
+      {root?.bskyUrl && (
+        <a
+          href={root.bskyUrl}
+          rel="noopener noreferrer"
+          style={calloutStyle}
+          target="_blank"
+        >
+          <span>
+            {hasBlueskyAccount
+              ? `You're signed in with @${blueskyHandle} — post and like directly on Bluesky`
+              : "Have a Bluesky account? View and join the conversation directly on Bluesky"}
+          </span>
+          <span aria-hidden="true" style={{ fontSize: "1.1rem" }}>
+            →
+          </span>
+        </a>
+      )}
+
+      {interactive && !hasBlueskyAccount && (
+        <form onSubmit={submitComment} style={{ margin: "1rem 0" }}>
+          <label
+            htmlFor={`bsky-comment-${paperId}`}
+            style={{ display: "none" }}
+          >
+            Add a comment
+          </label>
+          <textarea
+            disabled={submitting}
+            id={`bsky-comment-${paperId}`}
+            onChange={(event) => {
+              markInteraction();
+              setDraft(event.target.value);
+            }}
+            onFocus={markInteraction}
+            placeholder="Add a comment"
+            rows={3}
+            style={{
+              width: "100%",
+              padding: "0.6rem",
+              border: "1px solid #e5e7eb",
+              borderRadius: "0.5rem",
+              fontFamily: "inherit",
+              fontSize: "0.95rem",
+              resize: "vertical",
+            }}
+            value={draft}
+          />
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: "0.5rem 0.75rem",
+              marginTop: "0.5rem",
+              fontSize: "0.85rem",
+              color: "#6b7280",
+            }}
+          >
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.35rem",
+                cursor: submitting ? "default" : "pointer",
+              }}
+            >
+              <input
+                checked={anonymous}
+                disabled={submitting}
+                onChange={(event) => {
+                  markInteraction();
+                  setAnonymous(event.target.checked);
+                }}
+                type="checkbox"
+              />
+              Hide my name
+            </label>
+
+            {/* The section is already a polite live region, so a toggle of the
+                checkbox announces the new byline without one of its own. */}
+            <span style={{ color: "#374151" }}>
+              <span aria-hidden="true" style={{ color: "#9ca3af" }}>
+                ·{" "}
+              </span>
+              {attribution
+                ? `Posting as ${attribution}`
+                : "Posting under your pseudonym"}
+            </span>
+
+            <div
+              style={{
+                marginLeft: "auto",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.75rem",
+              }}
+            >
+              <small style={{ color: remaining < 0 ? "#b91c1c" : "#6b7280" }}>
+                {remaining}
+              </small>
+              <button
+                disabled={submitting || !draft.trim() || remaining < 0}
+                style={{
+                  padding: "0.4rem 0.9rem",
+                  borderRadius: "0.5rem",
+                  border: "1px solid #2563eb",
+                  backgroundColor: "#2563eb",
+                  color: "#fff",
+                  cursor: "pointer",
+                  fontSize: "0.9rem",
+                }}
+                type="submit"
+              >
+                {submitting ? "Posting…" : "Comment"}
+              </button>
+            </div>
+          </div>
+
+          {anonymous && (
+            <small
+              style={{
+                display: "block",
+                marginTop: "0.4rem",
+                fontSize: "0.8rem",
+                color: "#6b7280",
+              }}
+            >
+              Your name is hidden from readers, not from conference organizers.
+            </small>
+          )}
+        </form>
+      )}
+
+      {actionError && (
+        <p style={{ color: "#b91c1c", marginTop: 0 }}>{actionError}</p>
+      )}
+
+      {error && (
+        <p style={{ color: replies.length > 0 ? "#92400e" : "#b91c1c" }}>
+          {replies.length > 0
+            ? error
+            : `Could not load the discussion: ${error}`}
+        </p>
+      )}
+
+      {!error && replies.length === 0 && (
+        <p style={{ color: "#6b7280" }}>
+          No comments yet.{interactive ? " Start the conversation." : ""}
+        </p>
+      )}
+
       <div
         style={{
           display: "flex",
-          alignItems: "baseline",
+          alignItems: "center",
           flexWrap: "wrap",
           gap: "0.5rem 0.75rem",
-          marginBottom: "0.5rem",
+          margin: "0.9rem 0 0.2rem",
         }}
       >
-        <h2 style={{ margin: 0 }}>Discussion</h2>
+        {replies.length > 1 && (
+          <SortToggle
+            onChange={(next) => {
+              markInteraction();
+              setSort(next);
+            }}
+            sort={sort}
+          />
+        )}
 
         <div
           style={{
@@ -657,157 +830,6 @@ export default function BlueskyDiscussion({
           </button>
         </div>
       </div>
-      <style>{"@keyframes bsky-spin{to{transform:rotate(360deg)}}"}</style>
-
-      {root && <PostCard footer={rootFooter} post={root} variant="root" />}
-
-      {interactive && (
-        <form onSubmit={submitComment} style={{ margin: "1rem 0" }}>
-          <label
-            htmlFor={`bsky-comment-${paperId}`}
-            style={{ display: "none" }}
-          >
-            Add a comment
-          </label>
-          <textarea
-            disabled={submitting}
-            id={`bsky-comment-${paperId}`}
-            onChange={(event) => {
-              markInteraction();
-              setDraft(event.target.value);
-            }}
-            onFocus={markInteraction}
-            placeholder="Add a comment"
-            rows={3}
-            style={{
-              width: "100%",
-              padding: "0.6rem",
-              border: "1px solid #e5e7eb",
-              borderRadius: "0.5rem",
-              fontFamily: "inherit",
-              fontSize: "0.95rem",
-              resize: "vertical",
-            }}
-            value={draft}
-          />
-
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              flexWrap: "wrap",
-              gap: "0.5rem",
-              marginTop: "0.5rem",
-              fontSize: "0.85rem",
-              color: "#6b7280",
-            }}
-          >
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.35rem",
-                cursor: submitting ? "default" : "pointer",
-              }}
-            >
-              <input
-                checked={anonymous}
-                disabled={submitting}
-                onChange={(event) => {
-                  markInteraction();
-                  setAnonymous(event.target.checked);
-                }}
-                type="checkbox"
-              />
-              Hide my name
-            </label>
-
-            {/* The section is already a polite live region, so a toggle of the
-                checkbox announces the new byline without one of its own. */}
-            <span style={{ color: "#374151" }}>
-              <span aria-hidden="true" style={{ color: "#9ca3af" }}>
-                ·{" "}
-              </span>
-              {attribution
-                ? `Posting as ${attribution}`
-                : "Posting under your pseudonym"}
-            </span>
-          </div>
-
-          <small
-            style={{
-              display: "block",
-              marginTop: "0.3rem",
-              fontSize: "0.8rem",
-              color: "#6b7280",
-            }}
-          >
-            Your name is hidden from readers, not from conference organizers.
-          </small>
-
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "0.75rem",
-              marginTop: "0.6rem",
-            }}
-          >
-            <button
-              disabled={submitting || !draft.trim() || remaining < 0}
-              style={{
-                padding: "0.4rem 0.9rem",
-                borderRadius: "0.5rem",
-                border: "1px solid #2563eb",
-                backgroundColor: "#2563eb",
-                color: "#fff",
-                cursor: "pointer",
-                fontSize: "0.9rem",
-              }}
-              type="submit"
-            >
-              {submitting ? "Posting…" : "Comment"}
-            </button>
-
-            <small
-              style={{
-                marginLeft: "auto",
-                color: remaining < 0 ? "#b91c1c" : "#6b7280",
-              }}
-            >
-              {remaining}
-            </small>
-          </div>
-        </form>
-      )}
-
-      {actionError && (
-        <p style={{ color: "#b91c1c", marginTop: 0 }}>{actionError}</p>
-      )}
-
-      {error && (
-        <p style={{ color: replies.length > 0 ? "#92400e" : "#b91c1c" }}>
-          {replies.length > 0
-            ? error
-            : `Could not load the discussion: ${error}`}
-        </p>
-      )}
-
-      {!error && replies.length === 0 && (
-        <p style={{ color: "#6b7280" }}>
-          No comments yet.{interactive ? " Start the conversation." : ""}
-        </p>
-      )}
-
-      {replies.length > 1 && (
-        <SortToggle
-          onChange={(next) => {
-            markInteraction();
-            setSort(next);
-          }}
-          sort={sort}
-        />
-      )}
 
       {replies.map((reply, index) => (
         <ReplyThread
@@ -825,4 +847,21 @@ const sectionStyle: CSSProperties = {
   marginTop: "2rem",
   borderTop: "1px solid #d1d5db",
   paddingTop: "1.2rem",
+};
+
+/** The prominent "join on Bluesky" callout above the composer. */
+const calloutStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "0.75rem",
+  margin: "1rem 0 0.75rem",
+  padding: "0.7rem 0.9rem",
+  borderRadius: "0.6rem",
+  border: "1px solid #bfdbfe",
+  backgroundColor: "#eff6ff",
+  color: "#1e3a8a",
+  fontWeight: 600,
+  fontSize: "0.9rem",
+  textDecoration: "none",
 };

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -45,7 +45,7 @@ import type {
 import { usePolledThread } from "./bluesky/usePolledThread";
 
 const DEFAULT_API_BASES = ["https://bsky.tech.ieeevis.org"];
-const DEFAULT_REFRESH_MS = 30_000;
+const DEFAULT_REFRESH_MS = 5_000;
 const MAX_DEPTH = 5;
 const COMMENT_LIMIT = 250; // graphemes; mirrors CONFERENCE.guestTextLimit
 const TOKEN_REFRESH_SKEW_MS = 60_000;
@@ -117,6 +117,33 @@ function collectUris(
     }
   }
   return into;
+}
+
+/**
+ * A cheap fingerprint of a loaded thread: its state, how many replies it holds
+ * at any depth, and the merged like count. When any of these move, a poll
+ * brought something new and the polling cadence resets to the base interval.
+ */
+function threadSignature(loaded: LoadedThread): string {
+  const thread = loaded.thread;
+  if (thread.state !== "open" || !thread.post) {
+    return thread.state;
+  }
+  const replyCount = collectUris(thread.post.replies || []).size;
+  return `open:${replyCount}:${thread.post.totalLikeCount}`;
+}
+
+/** "updated 3s ago", "updated 2m ago", … for the freshness indicator. */
+function formatAgo(sinceMs: number): string {
+  const seconds = Math.max(0, Math.round(sinceMs / 1000));
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  return `${Math.floor(minutes / 60)}h ago`;
 }
 
 /**
@@ -244,6 +271,7 @@ export default function BlueskyDiscussion({
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingReplies, setPendingReplies] = useState<ShapedPost[]>([]);
   const [liked, setLiked] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   const { hasToken, getToken } = useGuestToken(Boolean(paperId));
 
@@ -291,10 +319,29 @@ export default function BlueskyDiscussion({
     [atUri, client, paperId],
   );
 
-  const { data, loading, error, refresh } = usePolledThread({
-    load,
-    refreshMs,
-  });
+  const { data, loading, error, refresh, lastUpdatedAt, sectionRef, markInteraction } =
+    usePolledThread({
+      load,
+      refreshMs,
+      signature: threadSignature,
+    });
+
+  // A once-a-second tick so the "updated Xs ago" label counts up on its own.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const onRefreshClick = useCallback(async () => {
+    markInteraction();
+    setRefreshing(true);
+    try {
+      await refresh(true);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [markInteraction, refresh]);
 
   const thread = data?.thread;
   /** Guest writes are bridged by the service; the AppView is read-only here. */
@@ -471,7 +518,7 @@ export default function BlueskyDiscussion({
 
   if (loading && !thread) {
     return (
-      <section style={sectionStyle} aria-live="polite">
+      <section ref={sectionRef} style={sectionStyle} aria-live="polite">
         <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
         <p style={{ color: "#6b7280" }}>Loading the discussion…</p>
       </section>
@@ -481,7 +528,7 @@ export default function BlueskyDiscussion({
   if (thread?.state === "not_open") {
     const opensAt = formatOpensAt(thread.opensAt);
     return (
-      <section style={sectionStyle} aria-live="polite">
+      <section ref={sectionRef} style={sectionStyle} aria-live="polite">
         <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
         <p style={{ color: "#6b7280", margin: 0 }}>
           {opensAt
@@ -542,8 +589,75 @@ export default function BlueskyDiscussion({
   }
 
   return (
-    <section style={sectionStyle} aria-live="polite">
-      <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
+    <section
+      ref={sectionRef}
+      style={sectionStyle}
+      aria-live="polite"
+      // Any click, tap or scroll gesture on the section counts as activity and
+      // resets the polling cadence to the base interval.
+      onPointerDown={markInteraction}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          flexWrap: "wrap",
+          gap: "0.5rem 0.75rem",
+          marginBottom: "0.5rem",
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Discussion</h2>
+
+        <div
+          style={{
+            marginLeft: "auto",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.6rem",
+            fontSize: "0.8rem",
+            color: "#6b7280",
+          }}
+        >
+          {lastUpdatedAt !== null && (
+            <span aria-live="off">
+              updated {formatAgo(now - lastUpdatedAt)}
+            </span>
+          )}
+          <button
+            aria-label="Refresh the discussion"
+            disabled={refreshing}
+            onClick={onRefreshClick}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.35rem",
+              padding: "0.25rem 0.6rem",
+              borderRadius: "0.5rem",
+              border: "1px solid #e5e7eb",
+              backgroundColor: "#fff",
+              color: "inherit",
+              cursor: refreshing ? "default" : "pointer",
+              fontSize: "0.8rem",
+              opacity: refreshing ? 0.6 : 1,
+            }}
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-block",
+                animation: refreshing
+                  ? "bsky-spin 0.8s linear infinite"
+                  : undefined,
+              }}
+            >
+              ↻
+            </span>
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+      </div>
+      <style>{"@keyframes bsky-spin{to{transform:rotate(360deg)}}"}</style>
 
       {root && <PostCard footer={rootFooter} post={root} variant="root" />}
 
@@ -558,7 +672,11 @@ export default function BlueskyDiscussion({
           <textarea
             disabled={submitting}
             id={`bsky-comment-${paperId}`}
-            onChange={(event) => setDraft(event.target.value)}
+            onChange={(event) => {
+              markInteraction();
+              setDraft(event.target.value);
+            }}
+            onFocus={markInteraction}
             placeholder="Add a comment"
             rows={3}
             style={{
@@ -595,7 +713,10 @@ export default function BlueskyDiscussion({
               <input
                 checked={anonymous}
                 disabled={submitting}
-                onChange={(event) => setAnonymous(event.target.checked)}
+                onChange={(event) => {
+                  markInteraction();
+                  setAnonymous(event.target.checked);
+                }}
                 type="checkbox"
               />
               Hide my name
@@ -678,7 +799,15 @@ export default function BlueskyDiscussion({
         </p>
       )}
 
-      {replies.length > 1 && <SortToggle onChange={setSort} sort={sort} />}
+      {replies.length > 1 && (
+        <SortToggle
+          onChange={(next) => {
+            markInteraction();
+            setSort(next);
+          }}
+          sort={sort}
+        />
+      )}
 
       {replies.map((reply, index) => (
         <ReplyThread

--- a/src/components/bluesky/Avatar.tsx
+++ b/src/components/bluesky/Avatar.tsx
@@ -1,0 +1,29 @@
+/** A post author's picture. Decorative: the name beside it is the label, so
+ *  the alt text stays empty and a missing picture renders nothing at all. */
+
+export default function Avatar({
+  src,
+  size,
+}: {
+  src: string | null;
+  size: number;
+}) {
+  if (!src) {
+    return null;
+  }
+
+  return (
+    <img
+      alt=""
+      src={src}
+      style={{
+        width: `${size}px`,
+        height: `${size}px`,
+        borderRadius: "9999px",
+        objectFit: "cover",
+        border: "1px solid #e5e7eb",
+        flexShrink: 0,
+      }}
+    />
+  );
+}

--- a/src/components/bluesky/Embeds.tsx
+++ b/src/components/bluesky/Embeds.tsx
@@ -1,0 +1,101 @@
+/** What a post carries besides its text: attached images, and the single link
+ *  card or quoted post a Bluesky post may have. */
+
+import { postUrl } from "./format";
+import type { EmbedImage, PostEmbed } from "./types";
+
+/** A grid of thumbnails, each linking to the full-size image. */
+export function EmbedImages({ images }: { images: EmbedImage[] }) {
+  if (!images || images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "0.5rem",
+        gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+        marginTop: "0.5rem",
+      }}
+    >
+      {images.map((image, index) => (
+        <a
+          href={image.fullsize || image.thumb}
+          key={`${image.thumb}-${index}`}
+          rel="noopener noreferrer"
+          style={{ display: "block" }}
+          target="_blank"
+        >
+          <img
+            alt={image.alt || ""}
+            src={image.thumb || image.fullsize}
+            style={{
+              width: "100%",
+              borderRadius: "0.5rem",
+              border: "1px solid #e5e7eb",
+            }}
+          />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+const cardStyle = {
+  display: "block",
+  border: "1px solid #e5e7eb",
+  borderRadius: "0.5rem",
+  marginTop: "0.5rem",
+  overflow: "hidden",
+  textDecoration: "none",
+  color: "inherit",
+} as const;
+
+/** The link preview or quote, rendered as one clickable card. */
+export function EmbedCard({ embed }: { embed?: PostEmbed | null }) {
+  if (!embed) {
+    return null;
+  }
+
+  if (embed.kind === "external") {
+    return (
+      <a
+        href={embed.uri}
+        rel="noopener noreferrer"
+        style={cardStyle}
+        target="_blank"
+      >
+        {embed.thumb && (
+          <img
+            alt=""
+            src={embed.thumb}
+            style={{ width: "100%", maxHeight: "180px", objectFit: "cover" }}
+          />
+        )}
+        <div style={{ padding: "0.6rem" }}>
+          <strong style={{ display: "block", marginBottom: "0.2rem" }}>
+            {embed.title}
+          </strong>
+          {embed.description && (
+            <small style={{ color: "#4b5563" }}>{embed.description}</small>
+          )}
+        </div>
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={postUrl(embed.uri) || "https://bsky.app"}
+      rel="noopener noreferrer"
+      style={{ ...cardStyle, padding: "0.6rem" }}
+      target="_blank"
+    >
+      <strong style={{ display: "block", marginBottom: "0.2rem" }}>
+        Quoted post by @{embed.author}
+      </strong>
+      <small>{embed.text || "Open the quoted post on Bluesky"}</small>
+    </a>
+  );
+}

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -38,8 +38,13 @@ export default function PostCard({
   const isRoot = variant === "root";
   const { name, body } = displayPost(post);
   const profile = post.guest ? null : profileUrl(post.author);
-  const permalink = post.guest ? null : postUrl(post.uri);
+  // Guest comments are real posts in the shared bridge repo, so their bsky.app
+  // permalink is valid too; only a not-yet-read-back placeholder URI has none.
+  const permalink = postUrl(post.uri);
   const time = formatRelativeTime(post.createdAt);
+  const timeTitle = post.createdAt
+    ? new Date(post.createdAt).toLocaleString()
+    : undefined;
   const likes = likeCountOf(post);
   const reposts = post.repostCount || 0;
 
@@ -78,11 +83,12 @@ export default function PostCard({
                 rel="noopener noreferrer"
                 style={{ color: "#2563eb", textDecoration: "none" }}
                 target="_blank"
+                title={timeTitle}
               >
                 {time}
               </a>
             ) : (
-              time
+              <span title={timeTitle}>{time}</span>
             )}
           </div>
         </div>

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -1,0 +1,122 @@
+/**
+ * One post: author, text, attachments, and a footer of counts.
+ *
+ * The author's name and handle only link out to bsky.app for posts made from a
+ * real account — guest comments all share one bridge account, so their
+ * pseudonym must not lead to that profile. The timestamp links to the post
+ * itself whenever it has a real URI, which a just-submitted comment does not
+ * yet have.
+ */
+
+import type { ReactNode } from "react";
+import Avatar from "./Avatar";
+import { EmbedCard, EmbedImages } from "./Embeds";
+import {
+  displayPost,
+  formatRelativeTime,
+  likeCountOf,
+  postUrl,
+  profileUrl,
+} from "./format";
+import type { ShapedPost } from "./types";
+
+interface PostCardProps {
+  post: ShapedPost;
+  /** "root" is the post a thread hangs off; "reply" is everything below it. */
+  variant?: "root" | "reply";
+  /** Replaces the default counts, e.g. with a like button on the root post. */
+  footer?: ReactNode;
+}
+
+const linkStyle = { color: "inherit", textDecoration: "none" } as const;
+
+export default function PostCard({
+  post,
+  variant = "reply",
+  footer,
+}: PostCardProps) {
+  const isRoot = variant === "root";
+  const { name, body } = displayPost(post);
+  const profile = post.guest ? null : profileUrl(post.author);
+  const permalink = post.guest ? null : postUrl(post.uri);
+  const time = formatRelativeTime(post.createdAt);
+  const likes = likeCountOf(post);
+  const reposts = post.repostCount || 0;
+
+  return (
+    <article
+      style={{
+        border: "1px solid #e5e7eb",
+        borderRadius: "0.6rem",
+        padding: isRoot ? "0.9rem" : "0.75rem",
+        backgroundColor: isRoot ? "#f9fafb" : "#fff",
+      }}
+    >
+      <header style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
+        <Avatar size={isRoot ? 40 : 36} src={post.author?.avatar ?? null} />
+        <div style={{ lineHeight: 1.2 }}>
+          {profile ? (
+            <a
+              href={profile}
+              rel="noopener noreferrer"
+              style={{ ...linkStyle, fontWeight: 600 }}
+              target="_blank"
+            >
+              {name}
+            </a>
+          ) : (
+            <span style={{ fontWeight: 600 }}>{name}</span>
+          )}
+          <div style={{ fontSize: "0.85rem", color: "#6b7280" }}>
+            {post.guest
+              ? "VIS attendee"
+              : `@${post.author?.handle || post.author?.did || "unknown"}`}
+            {time && " · "}
+            {time && permalink ? (
+              <a
+                href={permalink}
+                rel="noopener noreferrer"
+                style={{ color: "#2563eb", textDecoration: "none" }}
+                target="_blank"
+              >
+                {time}
+              </a>
+            ) : (
+              time
+            )}
+          </div>
+        </div>
+      </header>
+
+      <p
+        style={{
+          margin: isRoot ? "0.5rem 0" : "0.4rem 0",
+          whiteSpace: "pre-wrap",
+        }}
+      >
+        {body}
+      </p>
+      <EmbedImages images={post.embedImages} />
+      <EmbedCard embed={post.embed} />
+
+      <footer
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+          fontSize: "0.82rem",
+          color: "#6b7280",
+          marginTop: isRoot ? "0.6rem" : "0.5rem",
+        }}
+      >
+        {footer ?? (
+          <span>
+            {likes} {likes === 1 ? "like" : "likes"}
+            {reposts > 0 &&
+              ` · ${reposts} ${reposts === 1 ? "repost" : "reposts"}`}
+          </span>
+        )}
+      </footer>
+    </article>
+  );
+}

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -8,7 +8,7 @@
  * yet have.
  */
 
-import type { ReactNode } from "react";
+import type { CSSProperties } from "react";
 import Avatar from "./Avatar";
 import { EmbedCard, EmbedImages } from "./Embeds";
 import {
@@ -20,20 +20,134 @@ import {
 } from "./format";
 import type { ShapedPost } from "./types";
 
+/**
+ * Everything the per-post 🍩 like control needs, lifted to the discussion so
+ * the root and every reply read and update one shared like state.
+ *
+ *  - `likedUris` — the posts the reader has liked, updated optimistically.
+ *  - `deltas` — transient count adjustments applied on top of the server total
+ *    while an optimistic toggle is in flight; cleared when fresh data arrives.
+ *  - `canLike` — whether this reader may toggle likes at all (a service thread,
+ *    a valid token, and no linked Bluesky account of their own).
+ *  - `onToggle` — like/unlike the given post URI.
+ */
+export interface PostLikeContext {
+  canLike: boolean;
+  likedUris: Set<string>;
+  deltas: Map<string, number>;
+  onToggle: (postUri: string) => void;
+}
+
 interface PostCardProps {
   post: ShapedPost;
   /** "root" is the post a thread hangs off; "reply" is everything below it. */
   variant?: "root" | "reply";
-  /** Replaces the default counts, e.g. with a like button on the root post. */
-  footer?: ReactNode;
+  like?: PostLikeContext;
+  /**
+   * Drop the card's own border, corners and background so it can sit inside
+   * another bordered container (e.g. the announcement + Bluesky-callout box).
+   */
+  bare?: boolean;
 }
 
 const linkStyle = { color: "inherit", textDecoration: "none" } as const;
 
+/** The donut chip's shared shape; the button and the read-only count share it. */
+const likeChipStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.3rem",
+  padding: "0.25rem 0.7rem",
+  borderRadius: "0.5rem",
+  border: "1px solid #e5e7eb",
+  fontSize: "0.82rem",
+};
+
+/**
+ * The 🍩 like control for one post.
+ *
+ * The announcement root shows its Bluesky like count read-only — guests like
+ * the discussion's replies, not the announcement itself. Every reply, whether a
+ * guest comment or a native Bluesky reply, is an interactive donut once it is a
+ * real post and the reader may post; otherwise (a read-only viewer, a reader on
+ * Bluesky already, or a not-yet-read-back comment) it is a matching read-only
+ * chip, so the icon and count stay consistent without a control that does
+ * nothing.
+ */
+function LikeControl({
+  post,
+  isRoot,
+  like,
+}: {
+  post: ShapedPost;
+  isRoot: boolean;
+  like?: PostLikeContext;
+}) {
+  if (isRoot) {
+    // Bluesky's own like count for the announcement, read-only; we do not offer
+    // guest likes here and never sort by them.
+    return (
+      <span
+        aria-label={`${post.likeCount} likes on Bluesky`}
+        style={{
+          ...likeChipStyle,
+          backgroundColor: "transparent",
+          color: "#6b7280",
+        }}
+        title="Likes on Bluesky"
+      >
+        🍩 {post.likeCount}
+      </span>
+    );
+  }
+
+  // A just-posted comment not yet read back has a placeholder URI, so there is
+  // nothing real to like yet.
+  const isRealPost = post.uri.startsWith("at://");
+  const liked = like?.likedUris.has(post.uri) ?? false;
+  const count = likeCountOf(post) + (like?.deltas.get(post.uri) ?? 0);
+  const interactive = Boolean(like?.canLike) && isRealPost;
+
+  if (interactive) {
+    return (
+      <button
+        aria-label={`${liked ? "Unlike" : "Like"} this reply (${count})`}
+        aria-pressed={liked}
+        onClick={() => like?.onToggle(post.uri)}
+        style={{
+          ...likeChipStyle,
+          backgroundColor: liked ? "#eff6ff" : "#fff",
+          color: liked ? "#2563eb" : "inherit",
+          cursor: "pointer",
+        }}
+        title={liked ? "Unlike" : "Like"}
+        type="button"
+      >
+        🍩 {count}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      aria-label={`${count} likes`}
+      style={{
+        ...likeChipStyle,
+        backgroundColor: liked ? "#eff6ff" : "transparent",
+        color: liked ? "#2563eb" : "#6b7280",
+      }}
+      title="Likes"
+    >
+      🍩 {count}
+    </span>
+  );
+}
+
 export default function PostCard({
   post,
   variant = "reply",
-  footer,
+  like,
+  bare = false,
 }: PostCardProps) {
   const isRoot = variant === "root";
   const { name, body } = displayPost(post);
@@ -45,16 +159,15 @@ export default function PostCard({
   const timeTitle = post.createdAt
     ? new Date(post.createdAt).toLocaleString()
     : undefined;
-  const likes = likeCountOf(post);
   const reposts = post.repostCount || 0;
 
   return (
     <article
       style={{
-        border: "1px solid #e5e7eb",
-        borderRadius: "0.6rem",
+        border: bare ? "none" : "1px solid #e5e7eb",
+        borderRadius: bare ? 0 : "0.6rem",
         padding: isRoot ? "0.9rem" : "0.75rem",
-        backgroundColor: isRoot ? "#f9fafb" : "#fff",
+        backgroundColor: bare ? "transparent" : isRoot ? "#f9fafb" : "#fff",
       }}
     >
       <header style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
@@ -115,11 +228,10 @@ export default function PostCard({
           marginTop: isRoot ? "0.6rem" : "0.5rem",
         }}
       >
-        {footer ?? (
+        <LikeControl isRoot={isRoot} like={like} post={post} />
+        {!isRoot && reposts > 0 && (
           <span>
-            {likes} {likes === 1 ? "like" : "likes"}
-            {reposts > 0 &&
-              ` · ${reposts} ${reposts === 1 ? "repost" : "reposts"}`}
+            {reposts} {reposts === 1 ? "repost" : "reposts"}
           </span>
         )}
       </footer>

--- a/src/components/bluesky/ReplyList.tsx
+++ b/src/components/bluesky/ReplyList.tsx
@@ -1,0 +1,181 @@
+/**
+ * The top-level replies, animated when their order changes.
+ *
+ * Sorting by "Most liked" reorders the list as likes come in, and the reader
+ * can flip the sort outright; either way a bare re-render would make posts jump.
+ * A dependency-free FLIP keeps them followable: each frame we remember where
+ * every reply sat, and when the next render puts it somewhere new we start it
+ * from the old spot (an inverting transform) and let it transition home. Only
+ * these top-level items reorder — nested replies stay chronological — so the
+ * animation lives here and not in `ReplyThread`.
+ *
+ * Positions are measured relative to the list container, so scrolling the page
+ * between renders does not read as movement. Readers who ask for reduced motion
+ * get the plain jump.
+ */
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { PostLikeContext } from "./PostCard";
+import ReplyThread from "./ReplyThread";
+import type { ShapedPost } from "./types";
+
+const DURATION_MS = 200;
+
+interface ReplyListProps {
+  replies: ShapedPost[];
+  maxDepth: number;
+  like?: PostLikeContext;
+}
+
+interface Point {
+  left: number;
+  top: number;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+export default function ReplyList({ replies, maxDepth, like }: ReplyListProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const nodes = useRef<Map<string, HTMLDivElement>>(new Map());
+  const previous = useRef<Map<string, Point>>(new Map());
+  // The pending "play to zero" frame for each animating node, so an interrupting
+  // render can cancel it before it fights the next invert.
+  const plays = useRef<Map<string, number>>(new Map());
+  // Where each node last rested before its most recent move, timestamped. A move
+  // that lands a node back on this spot within one animation's span is a
+  // round-trip (a like then unlike, or a poll that reordered and reverted) rather
+  // than travel, so it settles in place instead of sliding out and back.
+  const settledAt = useRef<Map<string, { point: Point; at: number }>>(new Map());
+
+  const setNode = (key: string) => (element: HTMLDivElement | null) => {
+    if (element) {
+      nodes.current.set(key, element);
+    } else {
+      nodes.current.delete(key);
+    }
+  };
+
+  // Positions relative to the container, so page scroll cancels out. Any
+  // in-flight FLIP transform is stripped before reading, so the rect is the
+  // element's true resting layout position rather than a mid-animation offset —
+  // measuring a still-translating element would otherwise yield a wild delta and
+  // fling it out of the list. Clearing a transform does not move siblings (it is
+  // a paint-only offset), and the effect re-applies the invert synchronously
+  // before paint, so this never flashes.
+  const measure = (): Map<string, Point> => {
+    const points = new Map<string, Point>();
+    const container = containerRef.current?.getBoundingClientRect();
+    if (!container) {
+      return points;
+    }
+    for (const [key, element] of nodes.current) {
+      element.style.transition = "none";
+      element.style.transform = "";
+      const rect = element.getBoundingClientRect();
+      points.set(key, {
+        left: rect.left - container.left,
+        top: rect.top - container.top,
+      });
+    }
+    return points;
+  };
+
+  useLayoutEffect(() => {
+    // Drop any plays still queued from an interrupted reorder before measuring,
+    // so a stale frame cannot land on top of the invert we are about to set.
+    for (const id of plays.current.values()) {
+      cancelAnimationFrame(id);
+    }
+    plays.current.clear();
+
+    const current = measure();
+    const reduced = prefersReducedMotion();
+    const now = Date.now();
+
+    for (const [key, element] of nodes.current) {
+      const before = previous.current.get(key);
+      const after = current.get(key);
+      if (!before || !after) {
+        continue; // newly added — let it appear in place
+      }
+      const dx = before.left - after.left;
+      const dy = before.top - after.top;
+      if (dx === 0 && dy === 0) {
+        continue; // unmoved
+      }
+
+      // A move that returns a node to where it rested moments ago is a
+      // round-trip, not travel: a like immediately undone, or a poll that
+      // reordered the list and reverted. Its resting spot never truly changed —
+      // `measure` has already stripped the transform and put it in place — so let
+      // it settle rather than sliding it out and back. Bounding this to one
+      // animation's span keeps a genuine later move back to the same spot
+      // (someone re-likes) animating as usual.
+      const origin = settledAt.current.get(key);
+      const returned =
+        origin !== undefined &&
+        now - origin.at < DURATION_MS &&
+        origin.point.left === after.left &&
+        origin.point.top === after.top;
+      if (returned) {
+        settledAt.current.delete(key);
+        continue;
+      }
+
+      if (reduced) {
+        continue; // reduced motion — plain jump, no invert
+      }
+
+      // Record the spot being left, so an undo within the span above is caught.
+      settledAt.current.set(key, { point: before, at: now });
+
+      // Invert: jump back to the old spot with no transition…
+      element.style.transition = "none";
+      element.style.transform = `translate(${dx}px, ${dy}px)`;
+      // …then play forward to zero on the next frame.
+      const id = requestAnimationFrame(() => {
+        plays.current.delete(key);
+        element.style.transition = `transform ${DURATION_MS}ms ease`;
+        element.style.transform = "";
+      });
+      plays.current.set(key, id);
+    }
+
+    previous.current = current;
+  });
+
+  // Cancel any queued play on unmount so it cannot touch a detached node.
+  useEffect(() => {
+    const queued = plays.current;
+    return () => {
+      for (const id of queued.values()) {
+        cancelAnimationFrame(id);
+      }
+      queued.clear();
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      {replies.map((reply, index) => {
+        const key = reply.uri || `root-${index}`;
+        return (
+          <div key={key} ref={setNode(key)}>
+            <ReplyThread
+              depth={0}
+              like={like}
+              maxDepth={maxDepth}
+              post={reply}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/bluesky/ReplyThread.tsx
+++ b/src/components/bluesky/ReplyThread.tsx
@@ -5,18 +5,22 @@
  */
 
 import PostCard from "./PostCard";
+import type { PostLikeContext } from "./PostCard";
 import type { ShapedPost } from "./types";
 
 interface ReplyThreadProps {
   post: ShapedPost;
   depth: number;
   maxDepth: number;
+  /** Shared like state, threaded down so every reply gets its own control. */
+  like?: PostLikeContext;
 }
 
 export default function ReplyThread({
   post,
   depth,
   maxDepth,
+  like,
 }: ReplyThreadProps) {
   const replies = post.replies || [];
 
@@ -29,13 +33,14 @@ export default function ReplyThread({
         paddingLeft: depth > 0 ? "0.75rem" : 0,
       }}
     >
-      <PostCard post={post} />
+      <PostCard like={like} post={post} />
 
       {depth < maxDepth &&
         replies.map((reply, index) => (
           <ReplyThread
             depth={depth + 1}
             key={reply.uri || `${depth}-${index}`}
+            like={like}
             maxDepth={maxDepth}
             post={reply}
           />

--- a/src/components/bluesky/ReplyThread.tsx
+++ b/src/components/bluesky/ReplyThread.tsx
@@ -1,0 +1,53 @@
+/**
+ * A reply and everything under it, indented by depth. Past `maxDepth` the
+ * nesting is dropped rather than flattened — a deep argument reads better on
+ * Bluesky than as a column two characters wide.
+ */
+
+import PostCard from "./PostCard";
+import type { ShapedPost } from "./types";
+
+interface ReplyThreadProps {
+  post: ShapedPost;
+  depth: number;
+  maxDepth: number;
+}
+
+export default function ReplyThread({
+  post,
+  depth,
+  maxDepth,
+}: ReplyThreadProps) {
+  const replies = post.replies || [];
+
+  return (
+    <div
+      style={{
+        marginTop: "0.75rem",
+        marginLeft: depth * 12,
+        borderLeft: depth > 0 ? "2px solid #e5e7eb" : "none",
+        paddingLeft: depth > 0 ? "0.75rem" : 0,
+      }}
+    >
+      <PostCard post={post} />
+
+      {depth < maxDepth &&
+        replies.map((reply, index) => (
+          <ReplyThread
+            depth={depth + 1}
+            key={reply.uri || `${depth}-${index}`}
+            maxDepth={maxDepth}
+            post={reply}
+          />
+        ))}
+
+      {depth >= maxDepth && replies.length > 0 && (
+        <small
+          style={{ display: "block", marginTop: "0.4rem", color: "#6b7280" }}
+        >
+          Further replies are shown on Bluesky.
+        </small>
+      )}
+    </div>
+  );
+}

--- a/src/components/bluesky/SortToggle.tsx
+++ b/src/components/bluesky/SortToggle.tsx
@@ -1,9 +1,9 @@
-/** Orders the top-level replies: "Top" by likes, "Newest" by recency. */
+/** Orders the top-level replies: "Most liked" by likes, "Newest" by recency. */
 
 import type { ReplySort } from "./types";
 
 const OPTIONS: Array<{ value: ReplySort; label: string }> = [
-  { value: "top", label: "Top" },
+  { value: "top", label: "Most liked" },
   { value: "newest", label: "Newest" },
 ];
 
@@ -18,8 +18,15 @@ export default function SortToggle({
     <div
       aria-label="Sort comments"
       role="group"
-      style={{ display: "flex", gap: "0.4rem" }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.4rem",
+        fontSize: "0.82rem",
+        color: "#6b7280",
+      }}
     >
+      <span>Sort by:</span>
       {OPTIONS.map((option) => (
         <button
           aria-pressed={sort === option.value}

--- a/src/components/bluesky/SortToggle.tsx
+++ b/src/components/bluesky/SortToggle.tsx
@@ -1,0 +1,44 @@
+/** Orders the top-level replies: "Top" by likes, "Newest" by recency. */
+
+import type { ReplySort } from "./types";
+
+const OPTIONS: Array<{ value: ReplySort; label: string }> = [
+  { value: "top", label: "Top" },
+  { value: "newest", label: "Newest" },
+];
+
+export default function SortToggle({
+  sort,
+  onChange,
+}: {
+  sort: ReplySort;
+  onChange: (sort: ReplySort) => void;
+}) {
+  return (
+    <div
+      aria-label="Sort comments"
+      role="group"
+      style={{ display: "flex", gap: "0.4rem", margin: "0.9rem 0 0.2rem" }}
+    >
+      {OPTIONS.map((option) => (
+        <button
+          aria-pressed={sort === option.value}
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          style={{
+            padding: "0.2rem 0.7rem",
+            borderRadius: "0.5rem",
+            border: "1px solid #e5e7eb",
+            backgroundColor: sort === option.value ? "#eff6ff" : "#fff",
+            color: sort === option.value ? "#2563eb" : "#6b7280",
+            cursor: "pointer",
+            fontSize: "0.82rem",
+          }}
+          type="button"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/bluesky/SortToggle.tsx
+++ b/src/components/bluesky/SortToggle.tsx
@@ -18,7 +18,7 @@ export default function SortToggle({
     <div
       aria-label="Sort comments"
       role="group"
-      style={{ display: "flex", gap: "0.4rem", margin: "0.9rem 0 0.2rem" }}
+      style={{ display: "flex", gap: "0.4rem" }}
     >
       {OPTIONS.map((option) => (
         <button

--- a/src/components/bluesky/direct.ts
+++ b/src/components/bluesky/direct.ts
@@ -1,0 +1,37 @@
+/**
+ * Reads a thread straight from the public Bluesky AppView, no proxy involved.
+ * This is the source once a page knows the real `at://` URI of its post, and it
+ * is read-only: liking or replying needs a Bluesky account of one's own.
+ *
+ * Media stays on cdn.bsky.app — a reader who can reach the AppView can reach
+ * the CDN.
+ */
+
+import { normalizeAppViewThread } from "./normalize";
+import type { ThreadResponse } from "./types";
+
+const APPVIEW_BASE = "https://public.api.bsky.app";
+/** Deeper than any thread we render, so nesting is limited by display alone. */
+const FETCH_DEPTH = 10;
+
+export async function fetchAppViewThread(
+  atUri: string,
+  options: { signal?: AbortSignal; base?: string } = {},
+): Promise<ThreadResponse> {
+  const base = options.base || APPVIEW_BASE;
+  const response = await fetch(
+    `${base}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(atUri)}&depth=${FETCH_DEPTH}`,
+    { signal: options.signal, headers: { accept: "application/json" } },
+  );
+
+  // A deleted, blocked or misaddressed post answers 400/404; that is a state of
+  // the thread, not a failure worth retrying with backoff.
+  if (response.status === 400 || response.status === 404) {
+    return { state: "unavailable" };
+  }
+  if (!response.ok) {
+    throw new Error(`Bluesky returned ${response.status}.`);
+  }
+
+  return normalizeAppViewThread(await response.json());
+}

--- a/src/components/bluesky/direct.ts
+++ b/src/components/bluesky/direct.ts
@@ -21,7 +21,13 @@ export async function fetchAppViewThread(
   const base = options.base || APPVIEW_BASE;
   const response = await fetch(
     `${base}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(atUri)}&depth=${FETCH_DEPTH}`,
-    { signal: options.signal, headers: { accept: "application/json" } },
+    {
+      signal: options.signal,
+      headers: { accept: "application/json" },
+      // A poll or reload must never be served a stale browser-cached copy; the
+      // server cache still absorbs the load.
+      cache: "no-store",
+    },
   );
 
   // A deleted, blocked or misaddressed post answers 400/404; that is a state of

--- a/src/components/bluesky/format.ts
+++ b/src/components/bluesky/format.ts
@@ -1,0 +1,103 @@
+/** Presentation helpers for the shaped thread: dates, bsky.app links, and who
+ *  to credit for a post. */
+
+import type { RootPost, ShapedAuthor, ShapedPost } from "./types";
+
+export function formatRelativeTime(dateString?: string | null): string {
+  if (!dateString) {
+    return "";
+  }
+
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const deltaSeconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  const units = [
+    { label: "y", seconds: 31_536_000 },
+    { label: "mo", seconds: 2_592_000 },
+    { label: "d", seconds: 86_400 },
+    { label: "h", seconds: 3_600 },
+    { label: "m", seconds: 60 },
+  ];
+
+  for (const unit of units) {
+    if (deltaSeconds >= unit.seconds) {
+      return `${Math.floor(deltaSeconds / unit.seconds)}${unit.label}`;
+    }
+  }
+
+  return "now";
+}
+
+/** "Sat, Nov 10, 09:00 EST" in the reader's own timezone. */
+export function formatOpensAt(opensAt?: string | null): string {
+  if (!opensAt) {
+    return "";
+  }
+
+  const date = new Date(opensAt);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
+}
+
+export function profileUrl(author?: ShapedAuthor): string | null {
+  const id = author?.handle || author?.did;
+  return id ? `https://bsky.app/profile/${id}` : null;
+}
+
+/**
+ * The bsky.app permalink for an `at://did/app.bsky.feed.post/rkey` URI. Null
+ * for anything else, which includes the placeholder URIs of comments that have
+ * been posted but not yet read back from the service.
+ */
+export function postUrl(uri?: string): string | null {
+  const parts = (uri || "").split("/");
+  const did = parts[2];
+  const rkey = parts[4];
+  if (!uri?.startsWith("at://") || !did || !rkey) {
+    return null;
+  }
+  return `https://bsky.app/profile/${did}/post/${rkey}`;
+}
+
+/**
+ * Who to credit. Guest replies all live in one Bluesky account, so their
+ * attribution is baked into the post text as "💬 Ada Lovelace: …" — that is what
+ * readers on Bluesky itself see — and is stripped here so it is not shown twice.
+ * Replies whose author hid their name also carry `pseudonym`, which the service
+ * reads from our authorship log rather than by parsing text; prefer it when it
+ * is there.
+ */
+export function displayPost(post: ShapedPost): { name: string; body: string } {
+  const text = post.text || "";
+
+  if (post.guest) {
+    const match = /^💬\s*([^:]{1,80}):\s*/.exec(text);
+    return {
+      name: post.pseudonym || match?.[1]?.trim() || "VIS attendee",
+      body: match ? text.slice(match[0].length) : text,
+    };
+  }
+
+  return {
+    name: post.author?.displayName || post.author?.handle || "Unknown",
+    body: text,
+  };
+}
+
+/** Replies carry a plain `likeCount`; only the root has merged totals. */
+export function likeCountOf(post: ShapedPost | RootPost): number {
+  return "totalLikeCount" in post ? post.totalLikeCount : post.likeCount || 0;
+}

--- a/src/components/bluesky/format.ts
+++ b/src/components/bluesky/format.ts
@@ -97,7 +97,7 @@ export function displayPost(post: ShapedPost): { name: string; body: string } {
   };
 }
 
-/** Replies carry a plain `likeCount`; only the root has merged totals. */
+/** Every post carries the merged total; fall back to its own count defensively. */
 export function likeCountOf(post: ShapedPost | RootPost): number {
-  return "totalLikeCount" in post ? post.totalLikeCount : post.likeCount || 0;
+  return post.totalLikeCount ?? post.likeCount ?? 0;
 }

--- a/src/components/bluesky/normalize.ts
+++ b/src/components/bluesky/normalize.ts
@@ -1,0 +1,217 @@
+/**
+ * Turns either source's payload into the shaped thread of `types.ts`.
+ *
+ * The AppView side reshapes `app.bsky.feed.getPostThread` (only the parts the
+ * cards render — text, images, link cards, quotes, counts); the service side
+ * only fills in defaults, since it shapes the thread already. Both are
+ * defensive: a field that is missing or the wrong type must degrade to an empty
+ * rendering, never throw, because a live poll would then keep failing.
+ */
+
+import { postUrl } from "./format";
+import type {
+  EmbedImage,
+  PostEmbed,
+  RootPost,
+  ShapedAuthor,
+  ShapedPost,
+  ThreadResponse,
+} from "./types";
+
+// ─── app.bsky.feed.getPostThread ─────────────────────────────────────────────
+
+interface AppViewAuthor {
+  did?: string;
+  handle?: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+interface AppViewEmbed {
+  $type?: string;
+  images?: Array<{ thumb?: string; fullsize?: string; alt?: string }>;
+  external?: {
+    uri?: string;
+    title?: string;
+    description?: string;
+    thumb?: string;
+  };
+  record?: {
+    uri?: string;
+    author?: AppViewAuthor;
+    value?: { text?: string };
+  };
+  media?: AppViewEmbed;
+}
+
+interface AppViewPost {
+  uri?: string;
+  cid?: string;
+  indexedAt?: string;
+  author?: AppViewAuthor;
+  record?: { text?: string; createdAt?: string };
+  embed?: AppViewEmbed;
+  likeCount?: number;
+  repostCount?: number;
+}
+
+/** A node of the thread tree. Blocked and deleted posts arrive without `post`. */
+interface AppViewThread {
+  post?: AppViewPost;
+  replies?: AppViewThread[];
+}
+
+function normalizeAuthor(author?: AppViewAuthor): ShapedAuthor {
+  return {
+    did: author?.did,
+    handle: author?.handle,
+    displayName: author?.displayName || null,
+    avatar: author?.avatar || null,
+  };
+}
+
+function normalizeImages(embed?: AppViewEmbed): EmbedImage[] {
+  const images =
+    embed?.$type === "app.bsky.embed.images#view"
+      ? embed.images
+      : embed?.$type === "app.bsky.embed.recordWithMedia#view"
+        ? embed.media?.images
+        : undefined;
+
+  return (images || [])
+    .map((image) => ({
+      thumb: image.thumb || image.fullsize || "",
+      fullsize: image.fullsize || image.thumb || "",
+      alt: image.alt || "",
+    }))
+    .filter((image) => image.thumb);
+}
+
+function normalizeEmbed(embed?: AppViewEmbed): PostEmbed | null {
+  if (embed?.$type === "app.bsky.embed.external#view" && embed.external?.uri) {
+    return {
+      kind: "external",
+      uri: embed.external.uri,
+      title: embed.external.title || embed.external.uri,
+      description: embed.external.description || "",
+      thumb: embed.external.thumb || null,
+    };
+  }
+
+  const quote =
+    embed?.$type === "app.bsky.embed.record#view" ||
+    embed?.$type === "app.bsky.embed.recordWithMedia#view"
+      ? embed.record
+      : undefined;
+
+  if (quote?.uri) {
+    return {
+      kind: "record",
+      uri: quote.uri,
+      author: quote.author?.handle || quote.author?.did || "unknown",
+      text: quote.value?.text || "",
+    };
+  }
+
+  return null;
+}
+
+function normalizeNode(node: AppViewThread): ShapedPost | null {
+  const post = node?.post;
+  if (!post?.uri) {
+    return null;
+  }
+
+  return {
+    uri: post.uri,
+    cid: post.cid,
+    author: normalizeAuthor(post.author),
+    text: post.record?.text || "",
+    guest: false,
+    pseudonym: null,
+    likeCount: post.likeCount || 0,
+    repostCount: post.repostCount || 0,
+    createdAt: post.record?.createdAt || post.indexedAt || null,
+    embedImages: normalizeImages(post.embed),
+    embed: normalizeEmbed(post.embed),
+    replies: normalizeNodes(node.replies),
+  };
+}
+
+function normalizeNodes(nodes?: AppViewThread[]): ShapedPost[] {
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+  return nodes
+    .map(normalizeNode)
+    .filter((post): post is ShapedPost => post !== null);
+}
+
+/**
+ * The AppView knows nothing about guests, so the merged like counts collapse to
+ * the post's own: `totalLikeCount` is what the reader sees either way.
+ */
+export function normalizeAppViewThread(payload: unknown): ThreadResponse {
+  const thread = (payload as { thread?: AppViewThread } | null)?.thread;
+  const root = thread ? normalizeNode(thread) : null;
+
+  if (!root) {
+    return { state: "unavailable" };
+  }
+
+  const post: RootPost = {
+    ...root,
+    guestLikeCount: 0,
+    totalLikeCount: root.likeCount,
+    bskyUrl: postUrl(root.uri) || "https://bsky.app",
+  };
+
+  return { state: "open", post };
+}
+
+// ─── discussion service ──────────────────────────────────────────────────────
+
+function withDefaults(post: ShapedPost): ShapedPost {
+  return {
+    ...post,
+    author: post.author || { displayName: null, avatar: null },
+    text: post.text || "",
+    guest: Boolean(post.guest),
+    pseudonym: post.pseudonym ?? null,
+    likeCount: post.likeCount || 0,
+    createdAt: post.createdAt ?? null,
+    embedImages: Array.isArray(post.embedImages) ? post.embedImages : [],
+    embed: post.embed ?? null,
+    replies: Array.isArray(post.replies) ? post.replies.map(withDefaults) : [],
+  };
+}
+
+/** Passthrough with defaults; an unrecognized `state` counts as no thread. */
+export function normalizeServiceThread(
+  payload: unknown,
+  paperId: string,
+): ThreadResponse {
+  const data = payload as Partial<ThreadResponse> | null;
+
+  if (data?.state === "not_open") {
+    return { state: "not_open", paperId, opensAt: data.opensAt ?? null };
+  }
+
+  if (data?.state === "open") {
+    const post = (data as { post?: RootPost }).post;
+    return {
+      state: "open",
+      paperId,
+      post: post?.uri
+        ? {
+            ...withDefaults(post),
+            guestLikeCount: post.guestLikeCount || 0,
+            totalLikeCount: post.totalLikeCount ?? post.likeCount ?? 0,
+            bskyUrl: post.bskyUrl || postUrl(post.uri) || "https://bsky.app",
+          }
+        : undefined,
+    };
+  }
+
+  return { state: "unavailable", paperId };
+}

--- a/src/components/bluesky/normalize.ts
+++ b/src/components/bluesky/normalize.ts
@@ -130,6 +130,9 @@ function normalizeNode(node: AppViewThread): ShapedPost | null {
     guest: false,
     pseudonym: null,
     likeCount: post.likeCount || 0,
+    // The AppView has no guest likes, so the total is the post's own count.
+    guestLikeCount: 0,
+    totalLikeCount: post.likeCount || 0,
     repostCount: post.repostCount || 0,
     createdAt: post.record?.createdAt || post.indexedAt || null,
     embedImages: normalizeImages(post.embed),
@@ -161,8 +164,6 @@ export function normalizeAppViewThread(payload: unknown): ThreadResponse {
 
   const post: RootPost = {
     ...root,
-    guestLikeCount: 0,
-    totalLikeCount: root.likeCount,
     bskyUrl: postUrl(root.uri) || "https://bsky.app",
   };
 
@@ -179,6 +180,8 @@ function withDefaults(post: ShapedPost): ShapedPost {
     guest: Boolean(post.guest),
     pseudonym: post.pseudonym ?? null,
     likeCount: post.likeCount || 0,
+    guestLikeCount: post.guestLikeCount || 0,
+    totalLikeCount: post.totalLikeCount ?? post.likeCount ?? 0,
     createdAt: post.createdAt ?? null,
     embedImages: Array.isArray(post.embedImages) ? post.embedImages : [],
     embed: post.embed ?? null,
@@ -205,8 +208,6 @@ export function normalizeServiceThread(
       post: post?.uri
         ? {
             ...withDefaults(post),
-            guestLikeCount: post.guestLikeCount || 0,
-            totalLikeCount: post.totalLikeCount ?? post.likeCount ?? 0,
             bskyUrl: post.bskyUrl || postUrl(post.uri) || "https://bsky.app",
           }
         : undefined,

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -1,0 +1,134 @@
+/**
+ * Client for the conference discussion service (https://bsky.tech.ieeevis.org),
+ * which addresses threads by the paper's stable id — the page never handles
+ * post URIs — and is the only source that can accept writes, since guest
+ * comments and likes are bridged through it.
+ *
+ * A client owns the ordered list of origins it was built with and remembers
+ * which one last answered, so build it once per list rather than per request.
+ */
+
+import { normalizeServiceThread } from "./normalize";
+import type { ThreadResponse } from "./types";
+
+/** GET /api/threads/{paperId}/likes — `likedByMe` is null without a token. */
+export interface LikesResponse {
+  guestLikeCount: number;
+  likedByMe: boolean | null;
+}
+
+/**
+ * GET /api/me — who the bearer token belongs to. `name` is the attendee's real
+ * name from their conference login and is null when the service has none;
+ * `pseudonym` is their stable stand-in and is always present.
+ */
+export interface MeResponse {
+  name: string | null;
+  pseudonym: string;
+}
+
+export interface ServiceClient {
+  fetchThread(
+    paperId: string,
+    options?: { signal?: AbortSignal; fresh?: boolean },
+  ): Promise<ThreadResponse>;
+  fetchLikes(paperId: string, token: string): Promise<Response>;
+  fetchMe(token: string, options?: { signal?: AbortSignal }): Promise<Response>;
+  postComment(
+    paperId: string,
+    token: string,
+    text: string,
+    anonymous: boolean,
+  ): Promise<Response>;
+  setLike(paperId: string, token: string, liked: boolean): Promise<Response>;
+}
+
+export function createServiceClient(bases: string[]): ServiceClient {
+  let baseIndex = 0;
+
+  /**
+   * One pass over the API bases in order. A base is only abandoned when the
+   * request never completed (offline, DNS, blocked origin) — an HTTP error is
+   * an answer, and trying the next base would not produce a better one.
+   */
+  async function request(path: string, init?: RequestInit): Promise<Response> {
+    let lastError: unknown = new Error("No API base configured.");
+
+    for (let attempt = 0; attempt < bases.length; attempt++) {
+      const index = (baseIndex + attempt) % bases.length;
+      try {
+        const response = await fetch(`${bases[index]}${path}`, init);
+        baseIndex = index; // stick with whatever answered
+        return response;
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          throw err;
+        }
+        lastError = err;
+      }
+    }
+
+    throw lastError;
+  }
+
+  function threadPath(paperId: string, suffix = ""): string {
+    return `/api/threads/${encodeURIComponent(paperId)}${suffix}`;
+  }
+
+  return {
+    async fetchThread(paperId, options = {}) {
+      // `fresh` busts the shared nginx cache, for reading back one's own write.
+      const query = options.fresh ? `?fresh=${Date.now()}` : "";
+      const response = await request(threadPath(paperId) + query, {
+        signal: options.signal,
+        headers: { accept: "application/json" },
+      });
+
+      if (response.status === 404) {
+        return { state: "unavailable", paperId };
+      }
+      if (!response.ok) {
+        throw new Error(`The discussion service returned ${response.status}.`);
+      }
+
+      return normalizeServiceThread(await response.json(), paperId);
+    },
+
+    fetchLikes(paperId, token) {
+      return request(threadPath(paperId, "/likes"), {
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+        },
+      });
+    },
+
+    fetchMe(token, options = {}) {
+      return request("/api/me", {
+        signal: options.signal,
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+        },
+      });
+    },
+
+    postComment(paperId, token, text, anonymous) {
+      return request(threadPath(paperId, "/comments"), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ text, anonymous }),
+      });
+    },
+
+    setLike(paperId, token, liked) {
+      return request(threadPath(paperId, "/like"), {
+        method: liked ? "POST" : "DELETE",
+        headers: { authorization: `Bearer ${token}` },
+      });
+    },
+  };
+}

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -11,10 +11,13 @@
 import { normalizeServiceThread } from "./normalize";
 import type { ThreadResponse } from "./types";
 
-/** GET /api/threads/{paperId}/likes — `likedByMe` is null without a token. */
-export interface LikesResponse {
-  guestLikeCount: number;
-  likedByMe: boolean | null;
+/**
+ * GET /api/threads/{paperId}/my-likes — the URIs of the posts in this thread
+ * that the bearer's own reader has liked through the service. Empty without a
+ * token. Likes are per-post, so this is a set of URIs rather than one flag.
+ */
+export interface MyLikesResponse {
+  postUris: string[];
 }
 
 /**
@@ -36,7 +39,7 @@ export interface ServiceClient {
     paperId: string,
     options?: { signal?: AbortSignal; fresh?: boolean },
   ): Promise<ThreadResponse>;
-  fetchLikes(paperId: string, token: string): Promise<Response>;
+  fetchMyLikes(paperId: string, token: string): Promise<Response>;
   fetchMe(token: string, options?: { signal?: AbortSignal }): Promise<Response>;
   postComment(
     paperId: string,
@@ -44,7 +47,12 @@ export interface ServiceClient {
     text: string,
     anonymous: boolean,
   ): Promise<Response>;
-  setLike(paperId: string, token: string, liked: boolean): Promise<Response>;
+  setLike(
+    paperId: string,
+    token: string,
+    postUri: string,
+    liked: boolean,
+  ): Promise<Response>;
 }
 
 export function createServiceClient(bases: string[]): ServiceClient {
@@ -101,8 +109,8 @@ export function createServiceClient(bases: string[]): ServiceClient {
       return normalizeServiceThread(await response.json(), paperId);
     },
 
-    fetchLikes(paperId, token) {
-      return request(threadPath(paperId, "/likes"), {
+    fetchMyLikes(paperId, token) {
+      return request(threadPath(paperId, "/my-likes"), {
         headers: {
           accept: "application/json",
           authorization: `Bearer ${token}`,
@@ -131,10 +139,17 @@ export function createServiceClient(bases: string[]): ServiceClient {
       });
     },
 
-    setLike(paperId, token, liked) {
+    setLike(paperId, token, postUri, liked) {
+      // Likes are per-post: the body names which post in the thread, and the
+      // service validates that it is one a guest may like (the announcement or
+      // another guest comment, never a native Bluesky reply).
       return request(threadPath(paperId, "/like"), {
         method: liked ? "POST" : "DELETE",
-        headers: { authorization: `Bearer ${token}` },
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ postUri }),
       });
     },
   };

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -82,6 +82,9 @@ export function createServiceClient(bases: string[]): ServiceClient {
       const response = await request(threadPath(paperId) + query, {
         signal: options.signal,
         headers: { accept: "application/json" },
+        // Never serve a poll/reload a stale browser-cached copy; the shared
+        // nginx cache still absorbs the load.
+        cache: "no-store",
       });
 
       if (response.status === 404) {

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -20,11 +20,15 @@ export interface LikesResponse {
 /**
  * GET /api/me — who the bearer token belongs to. `name` is the attendee's real
  * name from their conference login and is null when the service has none;
- * `pseudonym` is their stable stand-in and is always present.
+ * `pseudonym` is their stable stand-in and is always present. `bluesky` is the
+ * reader's own Bluesky handle when they have linked an account, and null
+ * otherwise — its presence means they can post and like on Bluesky directly, so
+ * the guest composer is hidden for them.
  */
 export interface MeResponse {
   name: string | null;
   pseudonym: string;
+  bluesky: string | null;
 }
 
 export interface ServiceClient {

--- a/src/components/bluesky/types.ts
+++ b/src/components/bluesky/types.ts
@@ -1,0 +1,74 @@
+/**
+ * The one thread shape the Bluesky components render, whichever source it came
+ * from: the conference discussion service (already shaped server-side, see its
+ * `/openapi.json` — keep these types in step with it) or the public Bluesky
+ * AppView (shaped client-side by `normalize.ts`).
+ *
+ * Fields the AppView has no notion of — `guest`, `pseudonym`, `guestLikeCount`
+ * — are false/null/0 there. Fields the service does not send — `embed`,
+ * `repostCount` — are null/undefined in that direction. Everything else is
+ * present from both.
+ */
+
+export interface ShapedAuthor {
+  did?: string;
+  handle?: string;
+  displayName: string | null;
+  avatar: string | null;
+}
+
+export interface EmbedImage {
+  thumb: string;
+  fullsize: string;
+  alt: string;
+}
+
+/** A link card or a quoted post. Only the AppView source produces these. */
+export type PostEmbed =
+  | {
+      kind: "external";
+      uri: string;
+      title: string;
+      description: string;
+      thumb: string | null;
+    }
+  | { kind: "record"; uri: string; author: string; text: string };
+
+/** One post in the thread. Replies nest here — there is no top-level list. */
+export interface ShapedPost {
+  uri: string;
+  cid?: string;
+  author: ShapedAuthor;
+  text: string;
+  /** True when the post came through the guest bridge, from our authorship log. */
+  guest: boolean;
+  pseudonym: string | null;
+  likeCount: number;
+  repostCount?: number;
+  createdAt: string | null;
+  embedImages: EmbedImage[];
+  embed?: PostEmbed | null;
+  replies: ShapedPost[];
+}
+
+/** The root announcement post carries the merged counts and the Bluesky link. */
+export type RootPost = ShapedPost & {
+  guestLikeCount: number;
+  totalLikeCount: number;
+  bskyUrl: string;
+};
+
+/**
+ * "not_open" is a service-only state: it knows a paper's discussion is
+ * scheduled but not yet announced. A thread read straight from Bluesky is
+ * either there ("open") or not ("unavailable").
+ */
+export type ThreadResponse =
+  | { state: "open"; paperId?: string; post?: RootPost }
+  | { state: "not_open"; paperId?: string; opensAt?: string | null }
+  | { state: "unavailable"; paperId?: string };
+
+/** Where a thread was read from. Guest writes need the service. */
+export type ThreadSource = "service" | "direct";
+
+export type ReplySort = "top" | "newest";

--- a/src/components/bluesky/types.ts
+++ b/src/components/bluesky/types.ts
@@ -34,7 +34,15 @@ export type PostEmbed =
     }
   | { kind: "record"; uri: string; author: string; text: string };
 
-/** One post in the thread. Replies nest here — there is no top-level list. */
+/**
+ * One post in the thread. Replies nest here — there is no top-level list.
+ *
+ * Every post carries the merged like counts: `likeCount` is the post's own
+ * Bluesky likes, `guestLikeCount` the likes bridged through the service, and
+ * `totalLikeCount` the sum the reader sees. The AppView, which knows nothing of
+ * guests, reports `guestLikeCount` as 0 and `totalLikeCount` equal to
+ * `likeCount`.
+ */
 export interface ShapedPost {
   uri: string;
   cid?: string;
@@ -44,6 +52,8 @@ export interface ShapedPost {
   guest: boolean;
   pseudonym: string | null;
   likeCount: number;
+  guestLikeCount: number;
+  totalLikeCount: number;
   repostCount?: number;
   createdAt: string | null;
   embedImages: EmbedImage[];
@@ -51,10 +61,8 @@ export interface ShapedPost {
   replies: ShapedPost[];
 }
 
-/** The root announcement post carries the merged counts and the Bluesky link. */
+/** The root announcement post also carries the Bluesky link. */
 export type RootPost = ShapedPost & {
-  guestLikeCount: number;
-  totalLikeCount: number;
   bskyUrl: string;
 };
 

--- a/src/components/bluesky/usePolledThread.ts
+++ b/src/components/bluesky/usePolledThread.ts
@@ -1,0 +1,141 @@
+/**
+ * Polls a thread and keeps the last good answer on screen.
+ *
+ * The loading flag is only ever true before the first answer arrives, so a
+ * refresh never blanks the thread. Failures back off exponentially and are
+ * reported as a note beside the stale data rather than replacing it. Polling
+ * pauses while the tab is hidden and catches up as soon as it is shown again —
+ * a session room full of open paper pages should not poll all afternoon.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface PolledThreadOptions<T> {
+  /** Must be stable (`useCallback`); a new identity restarts the polling. */
+  load: (signal: AbortSignal, fresh: boolean) => Promise<T>;
+  /** 0 loads once and never refreshes. */
+  refreshMs: number;
+  pauseWhenHidden?: boolean;
+  maxBackoffMs?: number;
+}
+
+interface PolledThread<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  /** `fresh` skips the backoff wait and asks for an uncached answer. */
+  refresh: (fresh?: boolean) => Promise<void>;
+}
+
+export function usePolledThread<T>({
+  load,
+  refreshMs,
+  pauseWhenHidden = true,
+  maxBackoffMs = 300_000,
+}: PolledThreadOptions<T>): PolledThread<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasLoadedOnceRef = useRef(false);
+  const consecutiveFailuresRef = useRef(0);
+  const nextRequestAtRef = useRef(0);
+  const refreshRef = useRef<(fresh?: boolean) => Promise<void>>(async () => {});
+
+  useEffect(() => {
+    let disposed = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let controller: AbortController | null = null;
+    let isFetching = false;
+
+    async function refresh(fresh = false) {
+      if (disposed || isFetching) {
+        return;
+      }
+      if (!fresh && Date.now() < nextRequestAtRef.current) {
+        return;
+      }
+
+      isFetching = true;
+      const showLoading = !hasLoadedOnceRef.current;
+      if (showLoading) {
+        setLoading(true);
+      }
+      controller = new AbortController();
+
+      try {
+        const result = await load(controller.signal, fresh);
+        if (disposed) {
+          return;
+        }
+
+        setData(result);
+        hasLoadedOnceRef.current = true;
+        consecutiveFailuresRef.current = 0;
+        nextRequestAtRef.current = 0;
+        setError(null);
+      } catch (err) {
+        if ((err as Error).name === "AbortError" || disposed) {
+          return;
+        }
+
+        consecutiveFailuresRef.current += 1;
+        const backoffMs = Math.min(
+          refreshMs * 2 ** (consecutiveFailuresRef.current - 1),
+          maxBackoffMs,
+        );
+        nextRequestAtRef.current = Date.now() + backoffMs;
+
+        const message = (err as Error).message || "Could not load the thread.";
+        setError(
+          hasLoadedOnceRef.current
+            ? `Live updates paused (${message}). Retrying in ${Math.ceil(backoffMs / 1000)}s.`
+            : message,
+        );
+      } finally {
+        if (!disposed && showLoading) {
+          setLoading(false);
+        }
+        isFetching = false;
+        controller = null;
+      }
+    }
+
+    refreshRef.current = refresh;
+    void refresh();
+
+    if (refreshMs > 0) {
+      intervalId = setInterval(() => {
+        if (pauseWhenHidden && document.visibilityState !== "visible") {
+          return;
+        }
+        void refresh();
+      }, refreshMs);
+    }
+
+    function onVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        void refresh();
+      }
+    }
+
+    if (pauseWhenHidden) {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+
+    return () => {
+      disposed = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      if (pauseWhenHidden) {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
+      controller?.abort();
+    };
+  }, [load, maxBackoffMs, pauseWhenHidden, refreshMs]);
+
+  const refresh = useCallback((fresh = false) => refreshRef.current(fresh), []);
+
+  return { data, loading, error, refresh };
+}

--- a/src/components/bluesky/usePolledThread.ts
+++ b/src/components/bluesky/usePolledThread.ts
@@ -3,9 +3,22 @@
  *
  * The loading flag is only ever true before the first answer arrives, so a
  * refresh never blanks the thread. Failures back off exponentially and are
- * reported as a note beside the stale data rather than replacing it. Polling
- * pauses while the tab is hidden and catches up as soon as it is shown again —
- * a session room full of open paper pages should not poll all afternoon.
+ * reported as a note beside the stale data rather than replacing it.
+ *
+ * Polling is gated three ways so a session room full of open paper pages does
+ * not poll all afternoon:
+ *
+ *   - It pauses while the tab is hidden and refetches the moment it is shown.
+ *   - It pauses while the discussion is scrolled out of view (an
+ *     IntersectionObserver on the section) and refetches when it returns.
+ *   - While visible and on-screen it polls at the base interval, but the
+ *     interval grows (5s → 10s → … → ~120s) across polls that bring no new
+ *     content and no user activity, and snaps back to the base interval the
+ *     instant content changes, the reader interacts, or the section becomes
+ *     visible again.
+ *
+ * The content/activity backoff and the consecutive-failure backoff are separate
+ * mechanisms: the first sets the cadence, the second holds off after an error.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -13,10 +26,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 interface PolledThreadOptions<T> {
   /** Must be stable (`useCallback`); a new identity restarts the polling. */
   load: (signal: AbortSignal, fresh: boolean) => Promise<T>;
-  /** 0 loads once and never refreshes. */
+  /** Base interval, in ms. 0 loads once and never refreshes. */
   refreshMs: number;
   pauseWhenHidden?: boolean;
+  /** Cap for the consecutive-failure backoff. */
   maxBackoffMs?: number;
+  /** Cap for the no-new-content inactivity backoff. */
+  maxInactiveMs?: number;
+  /**
+   * Fingerprint of a result, used to tell a poll that changed something from
+   * one that did not. A changed fingerprint resets the interval to the base.
+   */
+  signature?: (data: T) => string;
 }
 
 interface PolledThread<T> {
@@ -25,28 +46,108 @@ interface PolledThread<T> {
   error: string | null;
   /** `fresh` skips the backoff wait and asks for an uncached answer. */
   refresh: (fresh?: boolean) => Promise<void>;
+  /** ms timestamp of the last successful fetch, or null before the first. */
+  lastUpdatedAt: number | null;
+  /** Attach to the section element to gate polling on its visibility. */
+  sectionRef: (element: Element | null) => void;
+  /** Reader touched the section: reset the interval to the base. */
+  markInteraction: () => void;
 }
+
+/** Doublings are clamped here; `maxInactiveMs` still caps the actual wait. */
+const MAX_INACTIVE_LEVEL = 8;
 
 export function usePolledThread<T>({
   load,
   refreshMs,
   pauseWhenHidden = true,
   maxBackoffMs = 300_000,
+  maxInactiveMs = 120_000,
+  signature,
 }: PolledThreadOptions<T>): PolledThread<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
 
   const hasLoadedOnceRef = useRef(false);
   const consecutiveFailuresRef = useRef(0);
   const nextRequestAtRef = useRef(0);
+  const lastSignatureRef = useRef<string | null>(null);
   const refreshRef = useRef<(fresh?: boolean) => Promise<void>>(async () => {});
+  const markInteractionRef = useRef<() => void>(() => {});
+
+  // On-screen truth shared between the observer (which writes it) and the
+  // polling effect (which reads it in `canPoll`). Defaults to true so polling
+  // works even when no section element is attached.
+  const onScreenRef = useRef(true);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const onScreenChangeRef = useRef<((onScreen: boolean) => void) | null>(null);
+
+  const sectionRef = useCallback((element: Element | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Start a little before the section reaches the viewport so content is
+        // fresh by the time the reader gets to it.
+        const onScreen = entries.some((entry) => entry.isIntersecting);
+        onScreenRef.current = onScreen;
+        onScreenChangeRef.current?.(onScreen);
+      },
+      { rootMargin: "300px 0px" },
+    );
+    observer.observe(element);
+    observerRef.current = observer;
+  }, []);
 
   useEffect(() => {
     let disposed = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
     let controller: AbortController | null = null;
     let isFetching = false;
+    let inactiveLevel = 0;
+
+    function isVisible() {
+      return !pauseWhenHidden || document.visibilityState === "visible";
+    }
+    function canPoll() {
+      return isVisible() && onScreenRef.current;
+    }
+
+    function inactiveIntervalMs() {
+      return Math.min(refreshMs * 2 ** inactiveLevel, maxInactiveMs);
+    }
+
+    function clearTimer() {
+      if (timerId) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
+    }
+
+    function scheduleNext() {
+      clearTimer();
+      if (disposed || refreshMs <= 0 || !canPoll()) {
+        return;
+      }
+      // Honour the error backoff too: whichever wait is longer wins.
+      const backoffWait = nextRequestAtRef.current - Date.now();
+      const delay = Math.max(inactiveIntervalMs(), backoffWait, 0);
+      timerId = setTimeout(onTick, delay);
+    }
+
+    async function onTick() {
+      timerId = null;
+      if (canPoll()) {
+        await refresh();
+      }
+      scheduleNext();
+    }
 
     async function refresh(fresh = false) {
       if (disposed || isFetching) {
@@ -69,11 +170,29 @@ export function usePolledThread<T>({
           return;
         }
 
+        const firstLoad = !hasLoadedOnceRef.current;
+        const nextSignature = signature ? signature(result) : null;
+        const changed =
+          nextSignature !== null &&
+          lastSignatureRef.current !== null &&
+          nextSignature !== lastSignatureRef.current;
+        if (nextSignature !== null) {
+          lastSignatureRef.current = nextSignature;
+        }
+
         setData(result);
         hasLoadedOnceRef.current = true;
         consecutiveFailuresRef.current = 0;
         nextRequestAtRef.current = 0;
         setError(null);
+        setLastUpdatedAt(Date.now());
+
+        // A manual/fresh poll counts as activity, so it also resets the cadence.
+        if (firstLoad || changed || fresh) {
+          inactiveLevel = 0;
+        } else {
+          inactiveLevel = Math.min(inactiveLevel + 1, MAX_INACTIVE_LEVEL);
+        }
       } catch (err) {
         if ((err as Error).name === "AbortError" || disposed) {
           return;
@@ -101,21 +220,42 @@ export function usePolledThread<T>({
       }
     }
 
-    refreshRef.current = refresh;
-    void refresh();
-
-    if (refreshMs > 0) {
-      intervalId = setInterval(() => {
-        if (pauseWhenHidden && document.visibilityState !== "visible") {
-          return;
-        }
-        void refresh();
-      }, refreshMs);
+    // Reset the cadence and refetch straight away — used when the section
+    // becomes visible or scrolls back into view.
+    function resumeNow() {
+      if (disposed) {
+        return;
+      }
+      inactiveLevel = 0;
+      clearTimer();
+      void refresh();
+      scheduleNext();
     }
+
+    refreshRef.current = refresh;
+    // A reader interaction resets the cadence without forcing a fetch.
+    markInteractionRef.current = () => {
+      inactiveLevel = 0;
+      scheduleNext();
+    };
+    onScreenChangeRef.current = (onScreen) => {
+      if (onScreen) {
+        resumeNow();
+      } else {
+        clearTimer();
+      }
+    };
+
+    // The first load is never gated on visibility, so the thread is ready to
+    // show the moment the reader arrives.
+    void refresh();
+    scheduleNext();
 
     function onVisibilityChange() {
       if (document.visibilityState === "visible") {
-        void refresh();
+        resumeNow();
+      } else {
+        clearTimer();
       }
     }
 
@@ -125,17 +265,25 @@ export function usePolledThread<T>({
 
     return () => {
       disposed = true;
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
+      clearTimer();
       if (pauseWhenHidden) {
         document.removeEventListener("visibilitychange", onVisibilityChange);
       }
+      onScreenChangeRef.current = null;
       controller?.abort();
     };
-  }, [load, maxBackoffMs, pauseWhenHidden, refreshMs]);
+  }, [load, maxBackoffMs, maxInactiveMs, pauseWhenHidden, refreshMs, signature]);
 
   const refresh = useCallback((fresh = false) => refreshRef.current(fresh), []);
+  const markInteraction = useCallback(() => markInteractionRef.current(), []);
 
-  return { data, loading, error, refresh };
+  return {
+    data,
+    loading,
+    error,
+    refresh,
+    lastUpdatedAt,
+    sectionRef,
+    markInteraction,
+  };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,8 +25,10 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
       "frame-ancestors 'none'",
       "form-action 'self'",
 
-      // IMAGES
-      "img-src 'self' data:",
+      // IMAGES — bsky.tech.ieeevis.org serves proxied avatars/images for the
+      // paper-page Bluesky discussions; cdn.bsky.app serves them for threads
+      // read straight from Bluesky
+      "img-src 'self' data: https://bsky.tech.ieeevis.org https://cdn.bsky.app",
 
       // FONTS
       "font-src 'self' https://fonts.gstatic.com data:",
@@ -41,8 +43,12 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
         ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
         : "script-src 'self'",
 
-      // NETWORK (HMR, APIs, etc.)
-      isDev ? "connect-src 'self' ws: http: https:" : "connect-src 'self'",
+      // NETWORK (HMR, APIs, etc.) — bsky.tech.ieeevis.org is the Bluesky
+      // discussion API for paper pages, public.api.bsky.app the Bluesky AppView
+      // that threads are read from directly
+      isDev
+        ? "connect-src 'self' ws: http: https:"
+        : "connect-src 'self' https://bsky.tech.ieeevis.org https://public.api.bsky.app",
 
       // Enforce HTTPS in prod only
       !isDev && "upgrade-insecure-requests",

--- a/src/pages/program/bluesky-discussion-demo.astro
+++ b/src/pages/program/bluesky-discussion-demo.astro
@@ -1,0 +1,36 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+import BlueskyDiscussion from "../../components/BlueskyDiscussion";
+
+const frontmatter = {
+  title: "Bluesky Discussion Demo",
+  active_nav: "Program",
+  contact: "web@ieeevis.org",
+};
+---
+
+<PageLayout frontmatter={frontmatter}>
+  <p>
+    This page demonstrates the paper-page discussion embed,
+    <code>src/components/BlueskyDiscussion.tsx</code>. Paper pages pass the
+    paper's id; the discussion service resolves it to the announcement post and
+    its reply thread.
+  </p>
+
+  <h2>By paper id (service)</h2>
+  <p>
+    Resolves <code>test-bsky-9999</code> through the discussion service. Shows
+    the "discussion opens…" state until the test announcement has been posted.
+  </p>
+  <BlueskyDiscussion paperId="test-bsky-9999" client:load />
+
+  <h2>By post URI (direct from Bluesky)</h2>
+  <p>
+    Reads a thread straight from the public Bluesky AppView — how paper pages
+    will work after the conference, once real post URIs are baked in.
+  </p>
+  <BlueskyDiscussion
+    atUri="at://did:plc:k644h4rq5bjfzcetgsa6tuby/app.bsky.feed.post/3lvpmtclfz22r"
+    client:load
+  />
+</PageLayout>

--- a/src/pages/program/paper/[paperId].astro
+++ b/src/pages/program/paper/[paperId].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
+import BlueskyDiscussion from "../../../components/BlueskyDiscussion";
 import { fetchAllPapers } from "../../../utils/paperData";
 import { features } from "../../../config/pages-allow-list";
 import { withBaseURL } from "../../../utils/withBaseURL";
@@ -260,6 +261,13 @@ const frontmatter = {
         </div>
       )
     }
+
+    <!-- Bluesky discussion: thread of replies to this paper's announcement
+         post, proxied through bsky.tech.ieeevis.org so it loads on any
+         conference network. Sortable by upvotes or recency. -->
+    <div class="mb-6 not-prose">
+      <BlueskyDiscussion client:visible paperId={paper.id} />
+    </div>
   </div>
 </PageLayout>
 


### PR DESCRIPTION
## What

Adds a **Discussion** section to each paper page showing the reply thread of the paper's Bluesky announcement post — with per-post likes, a **Most liked / Newest** sort, live updates, and guest posting for attendees without a Bluesky account — and consolidates the site's Bluesky UI into one shared component set.

- `src/components/bluesky/` — shared pieces: `PostCard`, `ReplyThread`, `ReplyList`, `SortToggle`, one normalized thread shape (`types.ts`, `normalize.ts`), a polling hook, and **two data sources that produce that same shape**: `service.ts` (conference discussion service, by paper id) and `direct.ts` (public Bluesky AppView, by `at://` URI).
- `src/components/BlueskyDiscussion.tsx` — the paper-page component. With a paper id it uses the service (which also reaches readers on networks where Bluesky is blocked); with a URI it reads Bluesky directly and falls back to the service. Comment/like UI appears only when the thread came from the service and the reader's session yields a token.
- `src/components/Bluesky.tsx` — thin wrapper over the shared pieces; props unchanged.
- `src/pages/program/paper/[paperId].astro` — mounts the component (`client:visible`) after the abstract, keyed by the paper UUID. `src/pages/program/bluesky-discussion-demo.astro` — demo exercising both sources.
- `src/middleware.ts` — CSP allowlist for the discussion service plus `public.api.bsky.app` / `cdn.bsky.app`.

## Likes

Every reply — guest comments **and** native Bluesky replies — carries a 🍩 like control anyone can tap without a Bluesky account; the count combines Bluesky likes with guest likes collected by the service. The announcement itself is a read-only count. Likes are optimistic and reconciled against the server so a stale poll can't flip the count, and the like feeds the sort key so a just-liked reply holds its place. A dependency-free **FLIP animation** slides replies when a like or a sort change reorders them (reduced-motion aware, and net-zero round-trips settle in place rather than sliding out and back).

## Guest identity

Signed-in attendees without a Bluesky account can comment and like (token endpoint: #2613). By default a comment is signed with the attendee's **real name**, because a discussion where questions carry names reads like the hallway conversation it replaces. A **"Hide my name"** checkbox swaps in a stable pseudonym (`p-4821`) for that post, with a note that the name is hidden from other readers, not from organizers. The submit button states exactly who will post — **"Comment as {name}"** — updating live as the checkbox toggles. If the reader already has a Bluesky account (via the optional `bluesky` claim from #2613), the composer is hidden and they're pointed to post natively on Bluesky.

## How it works

During the conference, pages address discussions by **paper UUID**; the service ([vis-bsky-bot](https://github.com/domoritz/vis-bsky-bot), run by @domoritz) resolves them to the announcement post it creates ~45 min before each session, proxies thread + images so discussions load on any conference network, honors Bluesky moderation labels / hidden replies / an organizer denylist, and accepts guest comments/likes. **After the conference**, recorded post URIs can be baked into the pages as `atUri`, the component reads Bluesky's public API directly, and the service can be retired without breaking any page.

## Live updates

Refreshes itself so readers see new comments within a few seconds without a reload, while staying cheap at conference scale: ~5s base polling, but only while the tab is visible **and** the section is on-screen; inactivity backoff (5s → … → ~2 min) that snaps back on new content or interaction; `no-store` fetch so a poll never shows a stale browser copy (the service's short server cache absorbs load); a manual **Refresh** button + an **"updated Xs ago"** indicator; absolute-timestamp tooltips; and an in-progress draft / the "Hide my name" toggle / focus all preserved across auto-refreshes.

## Status

The backend service is live at `https://bsky.tech.ieeevis.org`. Ready for review; depends on the auth-token endpoint (#2613) and an end-to-end pass before it ships. Build passes (`npm run build`, no broken links); `astro check` clean for added/changed files (the one reported error is pre-existing in `src/components/Search.tsx` on `vis2026`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
