### PR TITLE
Add /auth/token endpoint for Bluesky discussion guest posting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ APP_BASE_URL=http://localhost:4321/year/2026
 
 # Generate a unique value with: openssl rand -hex 32
 AUTH0_SESSION_SECRET=replace-with-a-random-64-character-hex-string
+
+# Shared secret for /auth/token, which lets signed-in attendees post to the
+# VIS Bluesky discussions (bsky.tech.ieeevis.org) without a Bluesky account.
+# Must match the bridge's BSKY_EMBED_TOKEN_SECRET (ask the tech chairs).
+AUTH_EMBED_TOKEN_SECRET=replace-with-a-random-64-character-hex-string

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -15,10 +15,38 @@ type Auth0Config = {
 };
 
 export type AuthenticatedUser = {
+  bskyHandle?: string;
   email?: string;
   name?: string;
   sub: string;
 };
+
+/**
+ * Namespaced custom claim carrying the attendee's linked Bluesky handle.
+ *
+ * Auth0 does not put `user_metadata` into ID tokens, and any non-standard
+ * claim must use a namespaced URI, so surfacing `user_metadata.bsky_handle`
+ * requires an Auth0 Login Action on the tenant:
+ *
+ *   exports.onExecutePostLogin = async (event, api) => {
+ *     const handle = event.user.user_metadata?.bsky_handle;
+ *     if (typeof handle === "string" && handle.trim()) {
+ *       api.idToken.setCustomClaim(
+ *         "https://ieeevis.org/bsky_handle",
+ *         handle.trim(),
+ *       );
+ *     }
+ *   };
+ *
+ * Without that Action this claim is simply absent and the `bluesky` token
+ * claim is omitted — the guest composer stays visible, which is the safe
+ * default.
+ */
+const BSKY_HANDLE_CLAIM = "https://ieeevis.org/bsky_handle";
+
+function readBskyHandle(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
 
 export type AuthTransaction = {
   nonce: string;
@@ -198,6 +226,7 @@ export async function readSession(
       return undefined;
     }
     return {
+      bskyHandle: readBskyHandle(payload.bskyHandle),
       email: typeof payload.email === "string" ? payload.email : undefined,
       name: typeof payload.name === "string" ? payload.name : undefined,
       sub: payload.sub,
@@ -249,6 +278,9 @@ export async function verifyAuth0IdToken(
   }
 
   return {
+    // Set by the Auth0 Login Action documented on BSKY_HANDLE_CLAIM; absent
+    // for attendees who have not linked a Bluesky account.
+    bskyHandle: readBskyHandle(payload[BSKY_HANDLE_CLAIM]),
     email: typeof payload.email === "string" ? payload.email : undefined,
     name: typeof payload.name === "string" ? payload.name : undefined,
     sub: payload.sub,

--- a/src/pages/auth/token.ts
+++ b/src/pages/auth/token.ts
@@ -1,0 +1,80 @@
+/**
+ * Mints a short-lived HS256 token that lets a signed-in attendee comment and
+ * like on the VIS Bluesky bridge (https://bsky.tech.ieeevis.org) without
+ * having a Bluesky account. The bridge verifies it with the same shared
+ * secret; there is no JWKS fetch and no Auth0 SDK on the bridge side.
+ *
+ * The token carries only `sub` and `name` — it is an attendee assertion, not
+ * an Auth0 access token, and must never be minted for an anonymous visitor.
+ *
+ * NEW ENVIRONMENT VARIABLE
+ *   AUTH_EMBED_TOKEN_SECRET — random string, at least 32 characters.
+ *   Set it in the local `.env` and in the Netlify site environment. The
+ *   identical value is stored on the bridge as the `bsky_keys` table row
+ *   `BSKY_EMBED_TOKEN_SECRET`. Rotating one side breaks guest comments until
+ *   the other side is updated.
+ */
+
+import type { APIRoute } from "astro";
+import { SignJWT } from "jose";
+import { readSession } from "../../lib/auth0";
+
+export const prerender = false;
+
+/** Minutes of validity. Short: the embed re-mints from the session as needed. */
+const TOKEN_MAX_AGE_SECONDS = 60 * 10;
+
+function getTokenSecret() {
+  // Astro loads values from .env into import.meta.env for local development.
+  // Netlify exposes runtime values through process.env in the server function.
+  const value = (
+    import.meta.env.AUTH_EMBED_TOKEN_SECRET ??
+    process.env.AUTH_EMBED_TOKEN_SECRET
+  )?.trim();
+  if (!value || value.startsWith("replace-with-")) {
+    throw new Error(
+      "Missing required environment variable: AUTH_EMBED_TOKEN_SECRET",
+    );
+  }
+  if (value.length < 32) {
+    throw new Error(
+      "AUTH_EMBED_TOKEN_SECRET must be at least 32 characters long.",
+    );
+  }
+  return new TextEncoder().encode(value);
+}
+
+function json(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      // Never cached: it is per-user and expires in minutes.
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+    },
+    status,
+  });
+}
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const user = await readSession(cookies);
+  if (!user) {
+    // Expected for a signed-out visitor. The embed reads this as "show the
+    // discussion read-only" and does not surface an error.
+    return json({ error: "not_authenticated" }, 401);
+  }
+
+  try {
+    const expiresAt = new Date(Date.now() + TOKEN_MAX_AGE_SECONDS * 1000);
+    const token = await new SignJWT({ name: user.name })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(user.sub)
+      .setIssuedAt()
+      .setExpirationTime(`${TOKEN_MAX_AGE_SECONDS}s`)
+      .sign(getTokenSecret());
+
+    return json({ expiresAt: expiresAt.toISOString(), token }, 200);
+  } catch (error) {
+    console.error("Unable to mint a discussion token:", error);
+    return json({ error: "token_unavailable" }, 500);
+  }
+};

--- a/src/pages/auth/token.ts
+++ b/src/pages/auth/token.ts
@@ -4,8 +4,10 @@
  * having a Bluesky account. The bridge verifies it with the same shared
  * secret; there is no JWKS fetch and no Auth0 SDK on the bridge side.
  *
- * The token carries only `sub` and `name` — it is an attendee assertion, not
- * an Auth0 access token, and must never be minted for an anonymous visitor.
+ * The token carries `sub`, `name`, and — only when the attendee has linked a
+ * Bluesky account — an optional `bluesky` claim with their handle. It is an
+ * attendee assertion, not an Auth0 access token, and must never be minted for
+ * an anonymous visitor.
  *
  * NEW ENVIRONMENT VARIABLE
  *   AUTH_EMBED_TOKEN_SECRET — random string, at least 32 characters.
@@ -65,7 +67,13 @@ export const GET: APIRoute = async ({ cookies }) => {
 
   try {
     const expiresAt = new Date(Date.now() + TOKEN_MAX_AGE_SECONDS * 1000);
-    const token = await new SignJWT({ name: user.name })
+    // Include the linked Bluesky handle only when present; the bridge reads a
+    // top-level `bluesky` claim to hide the guest composer for these attendees.
+    const claims: { name?: string; bluesky?: string } = { name: user.name };
+    if (user.bskyHandle) {
+      claims.bluesky = user.bskyHandle;
+    }
+    const token = await new SignJWT(claims)
       .setProtectedHeader({ alg: "HS256" })
       .setSubject(user.sub)
       .setIssuedAt()


### PR DESCRIPTION
## What

Adds `GET /auth/token`, built on the Auth0 work in #2404. It mints a **10-minute HS256 JWT** from the existing session cookie (via `readSession`), signed with a new `AUTH_EMBED_TOKEN_SECRET`, and returns it to the paper-page discussion embed. Anonymous visitors get a 401.

The token carries:
- **`sub`, `name`** — the attendee's identity, for attributing guest comments.
- **`bluesky`** *(optional)* — the attendee's linked Bluesky handle, included only when present. It lets the embed hide the guest composer for attendees who already have a Bluesky account (they post natively instead). The handle comes from `user_metadata.bsky_handle`, surfaced into the ID token by an Auth0 **Post-Login Action** as the namespaced claim `https://ieeevis.org/bsky_handle` (see `src/lib/auth0.ts`). When absent, the claim is omitted and the composer stays visible — the safe default.

## Why

The paper pages are getting embedded Bluesky discussions (#2612). Attendees **without** a Bluesky account comment/like through the conference's discussion bridge (`bsky.tech.ieeevis.org`, run by @domoritz), which needs proof the caller is a signed-in participant. This endpoint is that proof: the embed fetches the token and sends it as a Bearer header; the bridge verifies it with the same shared secret. No Auth0 tokens leave the site, no JWKS, ~80 lines.

## Setup

- **`AUTH_EMBED_TOKEN_SECRET`** (≥32 chars), documented in `.env.example`, set locally and in the Netlify site environment. The matching value lives on the bridge; @domoritz hands it over privately.
- **For the optional `bluesky` claim:** add the Auth0 Post-Login Action that copies `user_metadata.bsky_handle` to `https://ieeevis.org/bsky_handle` on the ID token, and populate `bsky_handle` on attendee profiles. Until both are in place the claim is simply omitted.

## Status

May need to hold until **#2404** lands and the bridge is deployed. `astro check` and the pre-commit build pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
