### PR TITLE
Add Apple Inc. as Silver sponsor

### DIFF
--- a/src/data/supporters.yml
+++ b/src/data/supporters.yml
@@ -34,12 +34,12 @@
     - name: "Autodesk"
       image: /assets/supporters/autodesk.png
       url: "https://www.autodesk.com/"
+    - name: "Apple Inc."
+      image: /assets/supporters/apple.png
+      url: "https://www.apple.com/"
 #     - name: "VISUAPPS GmbH"
 #       image: /assets/supporters/visuapps.png
 #       url: "https://www.visuapps.com/"
-#     - name: "Apple Inc."
-#       image: /assets/supporters/apple.png
-#       url: "https://www.apple.com"
 
 - category: Bronze
   image_size: 200


### PR DESCRIPTION
## Summary
- Add Apple Inc. as a Silver sponsor using the existing `apple.png` logo

## Test plan
- [ ] Confirm Apple appears under Silver on the supporters page
- [ ] Check logo renders correctly (size/contrast) on desktop and mobile

## After merge
Please run the deployment command after merging so this shows up on the site.