### PR TITLE
Apply moderation filtering to the direct Bluesky read path

### DIFF
--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -5,14 +5,18 @@
  * It reads from either of two sources, which deliver the same shaped thread
  * (`bluesky/types.ts`):
  *
- *   - `atUri` reads the thread straight from the public Bluesky AppView. This
- *     is what pages use once the real post URIs are known and baked in.
  *   - `paperId` reads it from the conference discussion service, which
  *     addresses threads by the paper's stable id, reaches readers behind
  *     networks that cannot see Bluesky, and is the only source that accepts
  *     guest writes.
+ *   - `atUri` reads the thread straight from the public Bluesky AppView. This
+ *     is what pages use once the real post URIs are known and baked in.
  *
- * Given both, the AppView is tried first and the service is the fallback.
+ * Given both, the service is tried first and the AppView is the fallback: the
+ * service holds the full moderation state — its own denylist as well as what
+ * the AppView reports — and it is the only side that takes writes. The AppView
+ * still answers when the service cannot.
+ *
  * Commenting and liking appear only when the thread came from the service and
  * the reader's site session yields a token; everything else is read-only.
  *
@@ -390,28 +394,28 @@ export default function BlueskyDiscussion({
 
   const load = useCallback(
     async (signal: AbortSignal, fresh: boolean): Promise<LoadedThread> => {
-      if (atUri) {
+      if (paperId) {
         try {
-          const thread = await fetchAppViewThread(atUri, { signal });
-          // Unreachable from here (blocked network) or not there at all: with a
-          // paper id the service can still answer, so let it try.
-          if (thread.state !== "unavailable" || !paperId) {
-            return { source: "direct", thread };
+          const thread = await client.fetchThread(paperId, { signal, fresh });
+          // Down, or holding no thread for this paper: with a post URI the
+          // AppView can still show it, so let it try.
+          if (thread.state !== "unavailable" || !atUri) {
+            return { source: "service", thread };
           }
         } catch (err) {
-          if ((err as Error).name === "AbortError" || !paperId) {
+          if ((err as Error).name === "AbortError" || !atUri) {
             throw err;
           }
         }
       }
 
-      if (!paperId) {
+      if (!atUri) {
         throw new Error("No Bluesky post URI or paper id was given.");
       }
 
       return {
-        source: "service",
-        thread: await client.fetchThread(paperId, { signal, fresh }),
+        source: "direct",
+        thread: await fetchAppViewThread(atUri, { signal }),
       };
     },
     [atUri, client, paperId],

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -12,10 +12,8 @@
  *   - `atUri` reads the thread straight from the public Bluesky AppView. This
  *     is what pages use once the real post URIs are known and baked in.
  *
- * Given both, the service is tried first and the AppView is the fallback: the
- * service holds the full moderation state — its own denylist as well as what
- * the AppView reports — and it is the only side that takes writes. The AppView
- * still answers when the service cannot.
+ * Given both, the service is tried first and the AppView is the fallback: only
+ * the service has the full moderation state, and only it takes writes.
  *
  * Commenting and liking appear only when the thread came from the service and
  * the reader's site session yields a token; everything else is read-only.

--- a/src/components/bluesky/direct.ts
+++ b/src/components/bluesky/direct.ts
@@ -17,12 +17,7 @@ const FETCH_DEPTH = 10;
 
 export async function fetchAppViewThread(
   atUri: string,
-  options: {
-    signal?: AbortSignal;
-    base?: string;
-    /** Dropped on top of what the thread's own threadgate hides. */
-    hiddenUris?: ReadonlySet<string>;
-  } = {},
+  options: { signal?: AbortSignal; base?: string } = {},
 ): Promise<ThreadResponse> {
   const base = options.base || APPVIEW_BASE;
   const response = await fetch(
@@ -50,5 +45,5 @@ export async function fetchAppViewThread(
     throw new Error(`Bluesky returned ${response.status}.`);
   }
 
-  return normalizeAppViewThread(await response.json(), options.hiddenUris);
+  return normalizeAppViewThread(await response.json());
 }

--- a/src/components/bluesky/direct.ts
+++ b/src/components/bluesky/direct.ts
@@ -5,10 +5,6 @@
  *
  * Media stays on cdn.bsky.app — a reader who can reach the AppView can reach
  * the CDN.
- *
- * The AppView moderates nothing on our behalf, so this path asks for the T&S
- * labeler's labels and `normalize.ts` drops what they mark — see
- * `moderation.ts`.
  */
 
 import { MODERATION_LABELER_DID } from "./moderation";
@@ -24,7 +20,7 @@ export async function fetchAppViewThread(
   options: {
     signal?: AbortSignal;
     base?: string;
-    /** Replies to drop on top of the ones the thread itself marks hidden. */
+    /** Dropped on top of what the thread's own threadgate hides. */
     hiddenUris?: ReadonlySet<string>;
   } = {},
 ): Promise<ThreadResponse> {
@@ -35,9 +31,8 @@ export async function fetchAppViewThread(
       signal: options.signal,
       headers: {
         accept: "application/json",
-        // Opt in to the default T&S labeler so its labels reach the post views
-        // we read; without this header the AppView attaches only self-labels.
-        // It answers CORS for this header, so the browser may send it.
+        // Without this the AppView applies self-labels only; it allows the
+        // header from the browser via CORS.
         "atproto-accept-labelers": MODERATION_LABELER_DID,
       },
       // A poll or reload must never be served a stale browser-cached copy; the

--- a/src/components/bluesky/direct.ts
+++ b/src/components/bluesky/direct.ts
@@ -5,8 +5,13 @@
  *
  * Media stays on cdn.bsky.app — a reader who can reach the AppView can reach
  * the CDN.
+ *
+ * The AppView moderates nothing on our behalf, so this path asks for the T&S
+ * labeler's labels and `normalize.ts` drops what they mark — see
+ * `moderation.ts`.
  */
 
+import { MODERATION_LABELER_DID } from "./moderation";
 import { normalizeAppViewThread } from "./normalize";
 import type { ThreadResponse } from "./types";
 
@@ -16,14 +21,25 @@ const FETCH_DEPTH = 10;
 
 export async function fetchAppViewThread(
   atUri: string,
-  options: { signal?: AbortSignal; base?: string } = {},
+  options: {
+    signal?: AbortSignal;
+    base?: string;
+    /** Replies to drop on top of the ones the thread itself marks hidden. */
+    hiddenUris?: ReadonlySet<string>;
+  } = {},
 ): Promise<ThreadResponse> {
   const base = options.base || APPVIEW_BASE;
   const response = await fetch(
     `${base}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(atUri)}&depth=${FETCH_DEPTH}`,
     {
       signal: options.signal,
-      headers: { accept: "application/json" },
+      headers: {
+        accept: "application/json",
+        // Opt in to the default T&S labeler so its labels reach the post views
+        // we read; without this header the AppView attaches only self-labels.
+        // It answers CORS for this header, so the browser may send it.
+        "atproto-accept-labelers": MODERATION_LABELER_DID,
+      },
       // A poll or reload must never be served a stale browser-cached copy; the
       // server cache still absorbs the load.
       cache: "no-store",
@@ -39,5 +55,5 @@ export async function fetchAppViewThread(
     throw new Error(`Bluesky returned ${response.status}.`);
   }
 
-  return normalizeAppViewThread(await response.json());
+  return normalizeAppViewThread(await response.json(), options.hiddenUris);
 }

--- a/src/components/bluesky/moderation.ts
+++ b/src/components/bluesky/moderation.ts
@@ -1,0 +1,124 @@
+/**
+ * What we drop from a thread read straight from the public Bluesky AppView.
+ *
+ * Anyone on Bluesky can reply under a conference announcement and so land on a
+ * paper page. The discussion service already filters those replies out before it
+ * answers; the AppView filters nothing — it hands back moderated and
+ * threadgate-hidden replies alike and expects the client to do the work. So the
+ * direct source has to apply the same rules here.
+ *
+ * This MIRRORS the service: vis-bsky-bot's `_shared/conference.ts` and
+ * `bsky-api/lib/threads.ts`. The names are deliberately identical so the two
+ * sides stay easy to diff — keep them in step, and change both together.
+ */
+
+/** A single label as a post view carries it (com.atproto.label.defs#label). */
+export interface Label {
+  val?: string;
+  src?: string;
+  /** A negation retracting a previously applied label — ignore it. */
+  neg?: boolean;
+}
+
+/**
+ * The default Bluesky Trust & Safety labeler. Its DID goes in the
+ * `atproto-accept-labelers` header on getPostThread so its labels (spam, hate,
+ * the adult-content set, …) are actually applied to the post views we read —
+ * without opting in, the AppView attaches only self-labels. This is the same
+ * labeler every stock Bluesky client trusts by default.
+ */
+export const MODERATION_LABELER_DID = "did:plc:ar7c4by46qjdydhdevvrndac";
+
+/**
+ * Label values that cause us to drop a reply (and its whole subtree) from a
+ * rendered thread. A label counts only when it is not negated (`neg !== true`).
+ *
+ *   - "!hide" / "!no-unauthenticated": global takedown / logged-out opt-out. We
+ *     read the thread logged-out, so "!no-unauthenticated" opt-outs bind us.
+ *   - "porn" / "sexual" / "nudity" / "graphic-media": the global adult-content
+ *     set — never appropriate on a conference page.
+ *   - "spam" / "hate": from the default T&S labeler above.
+ *
+ * The announcement ROOT is always kept regardless of labels — it is ours. Only
+ * replies are filtered.
+ */
+export const HIDE_LABELS: ReadonlySet<string> = new Set([
+  "!hide",
+  "!no-unauthenticated",
+  "porn",
+  "sexual",
+  "nudity",
+  "graphic-media",
+  "spam",
+  "hate",
+]);
+
+/** The post fields moderation reads; `normalize.ts`'s AppViewPost is a superset. */
+export interface LabeledNode {
+  post?: {
+    uri?: string;
+    labels?: Label[];
+    author?: { labels?: Label[] };
+  };
+}
+
+/** The root post's threadgate view — the only place hidden replies are listed. */
+export interface ThreadgateView {
+  record?: { hiddenReplies?: string[] };
+}
+
+/** A node whose root post may carry a threadgate. */
+interface GatedNode {
+  post?: { threadgate?: ThreadgateView };
+}
+
+/** Whether any non-negated label on this list is in HIDE_LABELS. */
+export function hasHideLabel(labels: Label[] | undefined): boolean {
+  if (!Array.isArray(labels)) {
+    return false;
+  }
+  return labels.some(
+    (label) => label?.neg !== true && HIDE_LABELS.has(label?.val ?? ""),
+  );
+}
+
+/**
+ * Whether a reply must be dropped from the rendered thread — and with it its
+ * whole subtree, since the caller never recurses into a hidden node. A reply is
+ * hidden when either moderation source says so:
+ *
+ *   1. LABELER LABELS — a hide-worthy label on the post OR its author.
+ *   2. HIDDEN URIS — the OP's threadgate `hiddenReplies`, plus any denylist the
+ *      caller passes in.
+ *
+ * Only ever called on replies. The root is normalized unconditionally (it is
+ * ours) and is never passed here.
+ */
+export function shouldHide(
+  node: LabeledNode,
+  hiddenUris: ReadonlySet<string>,
+): boolean {
+  const post = node?.post;
+  // Let the caller turn a blocked or deleted node (one without a post) into null
+  // on its own terms; it is not a moderation decision.
+  if (!post) {
+    return false;
+  }
+  if (post.uri && hiddenUris.has(post.uri)) {
+    return true;
+  }
+  return hasHideLabel(post.labels) || hasHideLabel(post.author?.labels);
+}
+
+/**
+ * The at-uris an organizer marked "hide reply" on, read from the root post's
+ * threadgate view (`app.bsky.feed.threadgate.hiddenReplies`). Empty when the OP
+ * has no threadgate or has hidden nothing. Only the root post carries this, so
+ * it is read once and then applies to every depth of the thread.
+ */
+export function threadgateHiddenReplies(node: GatedNode | undefined): string[] {
+  const hidden = node?.post?.threadgate?.record?.hiddenReplies;
+  return Array.isArray(hidden)
+    ? hidden.filter((uri): uri is string => typeof uri === "string")
+    : [];
+}

--- a/src/components/bluesky/moderation.ts
+++ b/src/components/bluesky/moderation.ts
@@ -1,46 +1,25 @@
 /**
- * What we drop from a thread read straight from the public Bluesky AppView.
+ * Mirrors vis-bsky-bot's `_shared/conference.ts` and `bsky-api/lib/threads.ts`,
+ * which drop the same replies server-side — change both together.
  *
- * Anyone on Bluesky can reply under a conference announcement and so land on a
- * paper page. The discussion service already filters those replies out before it
- * answers; the AppView filters nothing — it hands back moderated and
- * threadgate-hidden replies alike and expects the client to do the work. So the
- * direct source has to apply the same rules here.
- *
- * This MIRRORS the service: vis-bsky-bot's `_shared/conference.ts` and
- * `bsky-api/lib/threads.ts`. The names are deliberately identical so the two
- * sides stay easy to diff — keep them in step, and change both together.
+ * The AppView does none of this for us: it returns labelled and
+ * threadgate-hidden replies alike, and applies a labeler's labels only when we
+ * ask for that labeler by DID.
  */
 
-/** A single label as a post view carries it (com.atproto.label.defs#label). */
+/** com.atproto.label.defs#label. A negated label (`neg`) has been retracted. */
 export interface Label {
   val?: string;
   src?: string;
-  /** A negation retracting a previously applied label — ignore it. */
   neg?: boolean;
 }
 
-/**
- * The default Bluesky Trust & Safety labeler. Its DID goes in the
- * `atproto-accept-labelers` header on getPostThread so its labels (spam, hate,
- * the adult-content set, …) are actually applied to the post views we read —
- * without opting in, the AppView attaches only self-labels. This is the same
- * labeler every stock Bluesky client trusts by default.
- */
+/** The default Bluesky Trust & Safety labeler, which stock clients trust too. */
 export const MODERATION_LABELER_DID = "did:plc:ar7c4by46qjdydhdevvrndac";
 
 /**
- * Label values that cause us to drop a reply (and its whole subtree) from a
- * rendered thread. A label counts only when it is not negated (`neg !== true`).
- *
- *   - "!hide" / "!no-unauthenticated": global takedown / logged-out opt-out. We
- *     read the thread logged-out, so "!no-unauthenticated" opt-outs bind us.
- *   - "porn" / "sexual" / "nudity" / "graphic-media": the global adult-content
- *     set — never appropriate on a conference page.
- *   - "spam" / "hate": from the default T&S labeler above.
- *
- * The announcement ROOT is always kept regardless of labels — it is ours. Only
- * replies are filtered.
+ * We read threads logged-out, so both the "!hide" takedown and the
+ * "!no-unauthenticated" opt-out bind us.
  */
 export const HIDE_LABELS: ReadonlySet<string> = new Set([
   "!hide",
@@ -62,17 +41,11 @@ export interface LabeledNode {
   };
 }
 
-/** The root post's threadgate view — the only place hidden replies are listed. */
+/** Only the root post carries one, listing the replies the OP hid. */
 export interface ThreadgateView {
   record?: { hiddenReplies?: string[] };
 }
 
-/** A node whose root post may carry a threadgate. */
-interface GatedNode {
-  post?: { threadgate?: ThreadgateView };
-}
-
-/** Whether any non-negated label on this list is in HIDE_LABELS. */
 export function hasHideLabel(labels: Label[] | undefined): boolean {
   if (!Array.isArray(labels)) {
     return false;
@@ -82,25 +55,13 @@ export function hasHideLabel(labels: Label[] | undefined): boolean {
   );
 }
 
-/**
- * Whether a reply must be dropped from the rendered thread — and with it its
- * whole subtree, since the caller never recurses into a hidden node. A reply is
- * hidden when either moderation source says so:
- *
- *   1. LABELER LABELS — a hide-worthy label on the post OR its author.
- *   2. HIDDEN URIS — the OP's threadgate `hiddenReplies`, plus any denylist the
- *      caller passes in.
- *
- * Only ever called on replies. The root is normalized unconditionally (it is
- * ours) and is never passed here.
- */
+/** Replies only — the announcement root is ours, and never filtered. */
 export function shouldHide(
   node: LabeledNode,
   hiddenUris: ReadonlySet<string>,
 ): boolean {
   const post = node?.post;
-  // Let the caller turn a blocked or deleted node (one without a post) into null
-  // on its own terms; it is not a moderation decision.
+  // A blocked or deleted node carries no post; that is the caller's to drop.
   if (!post) {
     return false;
   }
@@ -110,14 +71,10 @@ export function shouldHide(
   return hasHideLabel(post.labels) || hasHideLabel(post.author?.labels);
 }
 
-/**
- * The at-uris an organizer marked "hide reply" on, read from the root post's
- * threadgate view (`app.bsky.feed.threadgate.hiddenReplies`). Empty when the OP
- * has no threadgate or has hidden nothing. Only the root post carries this, so
- * it is read once and then applies to every depth of the thread.
- */
-export function threadgateHiddenReplies(node: GatedNode | undefined): string[] {
-  const hidden = node?.post?.threadgate?.record?.hiddenReplies;
+export function threadgateHiddenReplies(
+  root: { post?: { threadgate?: ThreadgateView } } | undefined,
+): string[] {
+  const hidden = root?.post?.threadgate?.record?.hiddenReplies;
   return Array.isArray(hidden)
     ? hidden.filter((uri): uri is string => typeof uri === "string")
     : [];

--- a/src/components/bluesky/normalize.ts
+++ b/src/components/bluesky/normalize.ts
@@ -6,9 +6,6 @@
  * only fills in defaults, since it shapes the thread already. Both are
  * defensive: a field that is missing or the wrong type must degrade to an empty
  * rendering, never throw, because a live poll would then keep failing.
- *
- * The AppView side also moderates, because nothing upstream of it does: see
- * `moderation.ts`.
  */
 
 import { postUrl } from "./format";
@@ -30,7 +27,6 @@ interface AppViewAuthor {
   handle?: string;
   displayName?: string;
   avatar?: string;
-  /** Labels on the account itself — a labelled author hides all their replies. */
   labels?: Label[];
 }
 
@@ -61,7 +57,6 @@ interface AppViewPost {
   likeCount?: number;
   repostCount?: number;
   labels?: Label[];
-  /** Only the root post carries one; it lists the replies the OP hid. */
   threadgate?: ThreadgateView;
 }
 
@@ -154,11 +149,7 @@ function normalizeNode(
   };
 }
 
-/**
- * Replies, minus the ones moderation drops. The filter runs BEFORE the
- * recursion, so a hidden reply takes its whole subtree with it — the same
- * pruning the service does, and the reason a hidden node is never normalized.
- */
+/** Filtering before the recursion is what takes a hidden reply's subtree with it. */
 function normalizeNodes(
   nodes: AppViewThread[] | undefined,
   hiddenUris: ReadonlySet<string>,
@@ -176,11 +167,9 @@ function normalizeNodes(
  * The AppView knows nothing about guests, so the merged like counts collapse to
  * the post's own: `totalLikeCount` is what the reader sees either way.
  *
- * `extraHiddenUris` is for replies we know to hide from somewhere other than the
- * thread itself — a build-time snapshot of the service's denylist. It joins the
- * root threadgate's own hidden replies; both prune subtrees the same way. The
- * root is normalized whatever its labels say: it is our announcement, and a
- * filtered root would blank the whole discussion.
+ * `extraHiddenUris` joins the root threadgate's own hidden replies; it is for a
+ * build-time snapshot of the service's denylist. The root itself is never
+ * filtered — it is our announcement, and dropping it would blank the discussion.
  */
 export function normalizeAppViewThread(
   payload: unknown,

--- a/src/components/bluesky/normalize.ts
+++ b/src/components/bluesky/normalize.ts
@@ -6,9 +6,14 @@
  * only fills in defaults, since it shapes the thread already. Both are
  * defensive: a field that is missing or the wrong type must degrade to an empty
  * rendering, never throw, because a live poll would then keep failing.
+ *
+ * The AppView side also moderates, because nothing upstream of it does: see
+ * `moderation.ts`.
  */
 
 import { postUrl } from "./format";
+import type { Label, ThreadgateView } from "./moderation";
+import { shouldHide, threadgateHiddenReplies } from "./moderation";
 import type {
   EmbedImage,
   PostEmbed,
@@ -25,6 +30,8 @@ interface AppViewAuthor {
   handle?: string;
   displayName?: string;
   avatar?: string;
+  /** Labels on the account itself — a labelled author hides all their replies. */
+  labels?: Label[];
 }
 
 interface AppViewEmbed {
@@ -53,6 +60,9 @@ interface AppViewPost {
   embed?: AppViewEmbed;
   likeCount?: number;
   repostCount?: number;
+  labels?: Label[];
+  /** Only the root post carries one; it lists the replies the OP hid. */
+  threadgate?: ThreadgateView;
 }
 
 /** A node of the thread tree. Blocked and deleted posts arrive without `post`. */
@@ -116,7 +126,10 @@ function normalizeEmbed(embed?: AppViewEmbed): PostEmbed | null {
   return null;
 }
 
-function normalizeNode(node: AppViewThread): ShapedPost | null {
+function normalizeNode(
+  node: AppViewThread,
+  hiddenUris: ReadonlySet<string>,
+): ShapedPost | null {
   const post = node?.post;
   if (!post?.uri) {
     return null;
@@ -137,26 +150,48 @@ function normalizeNode(node: AppViewThread): ShapedPost | null {
     createdAt: post.record?.createdAt || post.indexedAt || null,
     embedImages: normalizeImages(post.embed),
     embed: normalizeEmbed(post.embed),
-    replies: normalizeNodes(node.replies),
+    replies: normalizeNodes(node.replies, hiddenUris),
   };
 }
 
-function normalizeNodes(nodes?: AppViewThread[]): ShapedPost[] {
+/**
+ * Replies, minus the ones moderation drops. The filter runs BEFORE the
+ * recursion, so a hidden reply takes its whole subtree with it — the same
+ * pruning the service does, and the reason a hidden node is never normalized.
+ */
+function normalizeNodes(
+  nodes: AppViewThread[] | undefined,
+  hiddenUris: ReadonlySet<string>,
+): ShapedPost[] {
   if (!Array.isArray(nodes)) {
     return [];
   }
   return nodes
-    .map(normalizeNode)
+    .filter((node) => !shouldHide(node, hiddenUris))
+    .map((node) => normalizeNode(node, hiddenUris))
     .filter((post): post is ShapedPost => post !== null);
 }
 
 /**
  * The AppView knows nothing about guests, so the merged like counts collapse to
  * the post's own: `totalLikeCount` is what the reader sees either way.
+ *
+ * `extraHiddenUris` is for replies we know to hide from somewhere other than the
+ * thread itself — a build-time snapshot of the service's denylist. It joins the
+ * root threadgate's own hidden replies; both prune subtrees the same way. The
+ * root is normalized whatever its labels say: it is our announcement, and a
+ * filtered root would blank the whole discussion.
  */
-export function normalizeAppViewThread(payload: unknown): ThreadResponse {
+export function normalizeAppViewThread(
+  payload: unknown,
+  extraHiddenUris: ReadonlySet<string> = new Set<string>(),
+): ThreadResponse {
   const thread = (payload as { thread?: AppViewThread } | null)?.thread;
-  const root = thread ? normalizeNode(thread) : null;
+  const hiddenUris = new Set<string>([
+    ...threadgateHiddenReplies(thread),
+    ...extraHiddenUris,
+  ]);
+  const root = thread ? normalizeNode(thread, hiddenUris) : null;
 
   if (!root) {
     return { state: "unavailable" };

--- a/src/components/bluesky/normalize.ts
+++ b/src/components/bluesky/normalize.ts
@@ -167,19 +167,12 @@ function normalizeNodes(
  * The AppView knows nothing about guests, so the merged like counts collapse to
  * the post's own: `totalLikeCount` is what the reader sees either way.
  *
- * `extraHiddenUris` joins the root threadgate's own hidden replies; it is for a
- * build-time snapshot of the service's denylist. The root itself is never
- * filtered — it is our announcement, and dropping it would blank the discussion.
+ * The root is never filtered — it is our announcement, and dropping it would
+ * blank the discussion.
  */
-export function normalizeAppViewThread(
-  payload: unknown,
-  extraHiddenUris: ReadonlySet<string> = new Set<string>(),
-): ThreadResponse {
+export function normalizeAppViewThread(payload: unknown): ThreadResponse {
   const thread = (payload as { thread?: AppViewThread } | null)?.thread;
-  const hiddenUris = new Set<string>([
-    ...threadgateHiddenReplies(thread),
-    ...extraHiddenUris,
-  ]);
+  const hiddenUris = new Set(threadgateHiddenReplies(thread));
   const root = thread ? normalizeNode(thread, hiddenUris) : null;
 
   if (!root) {


### PR DESCRIPTION
The direct AppView path (`atUri`) filtered nothing, so replies hidden on Bluesky still rendered on paper pages. The service path (`paperId`) already filtered them.

`getPostThread` returns threadgate-hidden replies, and attaches only self-labels unless the client opts into a labeler. Filtering is the client's job. Verified against a real gated thread.

The direct path now drops a reply when either applies, matching the service:

- a hide-set label on the post or its author (`!hide`, `!no-unauthenticated`, the adult-content set, `spam`, `hate`)
- its URI is in the root threadgate's `hiddenReplies`

A dropped reply takes its subtree with it. The announcement root is never filtered.

New `bluesky/moderation.ts` mirrors vis-bsky-bot's `lib/threads.ts` and `_shared/conference.ts` — same names, keep them in step.

The second commit is separately droppable: with both `paperId` and `atUri`, the service now wins, since only it has the full moderation state and takes writes.

**Testing:** `npm run typecheck` reports the same 2 pre-existing errors before and after; `astro build` passed. The repo has no test runner, so the predicates ship without unit tests. Manual check: the second embed on `/program/bluesky-discussion-demo` reads by `atUri` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGxt1cxp9XVXWnfZZEKKen




---

**Merge order:** Merge after #2649 — both edit `src/components/BlueskyDiscussion.tsx` and conflict. Suggested order: #2649 → #2650 → #2651. Independent of #2648, but note #2648 moves the demo page referenced under Testing to `/demo/bluesky-discussion`.
