### PR TITLE
Let every signed-in attendee use the guest composer, and nudge linked accounts to Bluesky

### DIFF
--- a/src/components/Bluesky.tsx
+++ b/src/components/Bluesky.tsx
@@ -5,7 +5,7 @@
  * it, and replying happens on Bluesky.
  *
  * Pages that need the conference discussion service — threads addressed by
- * paper id, comments from attendees without a Bluesky account — use
+ * paper id, comments from signed-in attendees — use
  * `BlueskyDiscussion`. Both render the same cards.
  */
 

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -383,6 +383,10 @@ export default function BlueskyDiscussion({
   const attribution = anonymous
     ? identity?.pseudonym
     : identity?.name || identity?.pseudonym;
+  // A reader who has linked a Bluesky account is invited to reply there under
+  // their own name; the composer and the like button stay open to them either way.
+  const blueskyHandle = identity?.bluesky?.trim() || null;
+  const hasBlueskyAccount = Boolean(blueskyHandle);
 
   const load = useCallback(
     async (signal: AbortSignal, fresh: boolean): Promise<LoadedThread> => {
@@ -790,7 +794,20 @@ export default function BlueskyDiscussion({
               style={calloutFooterStyle}
               target="_blank"
             >
-              <span>🦋 View or join this discussion on Bluesky</span>
+              {hasBlueskyAccount ? (
+                <span style={calloutNudgeStyle}>
+                  <span>
+                    🦋 You're on Bluesky as @{blueskyHandle} — reply there if you
+                    like
+                  </span>
+                  <span style={calloutNudgeReasonStyle}>
+                    Your reply then appears under your own account instead of the
+                    shared bridge account.
+                  </span>
+                </span>
+              ) : (
+                <span>🦋 View or join this discussion on Bluesky</span>
+              )}
               <span aria-hidden="true" style={{ fontSize: "1.1rem" }}>
                 →
               </span>
@@ -1060,4 +1077,17 @@ const calloutFooterStyle: CSSProperties = {
   fontWeight: 600,
   fontSize: "0.9rem",
   textDecoration: "none",
+};
+
+/** The linked-account invitation, stacked over its quieter reason line. */
+const calloutNudgeStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.15rem",
+};
+
+const calloutNudgeReasonStyle: CSSProperties = {
+  fontWeight: 400,
+  fontSize: "0.82rem",
+  color: "#1e40af",
 };

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -383,10 +383,6 @@ export default function BlueskyDiscussion({
   const attribution = anonymous
     ? identity?.pseudonym
     : identity?.name || identity?.pseudonym;
-  // A reader who has linked a Bluesky account can post and like there directly,
-  // so we hide the guest composer for them and point them at the thread instead.
-  const blueskyHandle = identity?.bluesky?.trim() || null;
-  const hasBlueskyAccount = Boolean(blueskyHandle);
 
   const load = useCallback(
     async (signal: AbortSignal, fresh: boolean): Promise<LoadedThread> => {
@@ -757,7 +753,7 @@ export default function BlueskyDiscussion({
   // The like control is the same on the root and every reply; the discussion
   // owns the state so they all read and update one shared source.
   const likeContext: PostLikeContext = {
-    canLike: interactive && !hasBlueskyAccount,
+    canLike: interactive,
     likedUris,
     deltas: activeDeltas,
     onToggle: toggleLike,
@@ -794,11 +790,7 @@ export default function BlueskyDiscussion({
               style={calloutFooterStyle}
               target="_blank"
             >
-              <span>
-                {hasBlueskyAccount
-                  ? `🦋 You're on Bluesky as @${blueskyHandle} — post and like directly there`
-                  : "🦋 View or join this discussion on Bluesky"}
-              </span>
+              <span>🦋 View or join this discussion on Bluesky</span>
               <span aria-hidden="true" style={{ fontSize: "1.1rem" }}>
                 →
               </span>
@@ -807,7 +799,7 @@ export default function BlueskyDiscussion({
         </div>
       )}
 
-      {interactive && !hasBlueskyAccount && (
+      {interactive && (
         <form onSubmit={submitComment} style={{ margin: "1rem 0" }}>
           <label
             htmlFor={`bsky-comment-${paperId}`}

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -27,8 +27,8 @@ import type { ShapedPost } from "./types";
  *  - `likedUris` — the posts the reader has liked, updated optimistically.
  *  - `deltas` — transient count adjustments applied on top of the server total
  *    while an optimistic toggle is in flight; cleared when fresh data arrives.
- *  - `canLike` — whether this reader may toggle likes at all (a service thread,
- *    a valid token, and no linked Bluesky account of their own).
+ *  - `canLike` — whether this reader may toggle likes at all (a service thread
+ *    and a valid token).
  *  - `onToggle` — like/unlike the given post URI.
  */
 export interface PostLikeContext {

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -25,7 +25,8 @@ export interface MyLikesResponse {
  * name from their conference login and is null when the service has none;
  * `pseudonym` is their stable stand-in and is always present. `bluesky` is the
  * reader's own Bluesky handle when they have linked an account, and null
- * otherwise.
+ * otherwise — its presence invites them to reply natively on Bluesky and gates
+ * nothing.
  */
 export interface MeResponse {
   name: string | null;

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -25,8 +25,7 @@ export interface MyLikesResponse {
  * name from their conference login and is null when the service has none;
  * `pseudonym` is their stable stand-in and is always present. `bluesky` is the
  * reader's own Bluesky handle when they have linked an account, and null
- * otherwise — its presence means they can post and like on Bluesky directly, so
- * the guest composer is hidden for them.
+ * otherwise.
  */
 export interface MeResponse {
   name: string | null;

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -39,8 +39,7 @@ export type AuthenticatedUser = {
  *   };
  *
  * Without that Action this claim is simply absent and the `bluesky` token
- * claim is omitted — the guest composer stays visible, which is the safe
- * default.
+ * claim is omitted.
  */
 const BSKY_HANDLE_CLAIM = "https://ieeevis.org/bsky_handle";
 

--- a/src/pages/auth/token.ts
+++ b/src/pages/auth/token.ts
@@ -67,8 +67,8 @@ export const GET: APIRoute = async ({ cookies, url }) => {
 
   try {
     const expiresAt = new Date(Date.now() + TOKEN_MAX_AGE_SECONDS * 1000);
-    // Include the linked Bluesky handle only when present; the bridge reads a
-    // top-level `bluesky` claim to hide the guest composer for these attendees.
+    // Include the linked Bluesky handle only when present; the bridge reads it
+    // from a top-level `bluesky` claim.
     const claims: { name?: string; bluesky?: string } = { name: user.name };
     if (user.bskyHandle) {
       claims.bluesky = user.bskyHandle;


### PR DESCRIPTION
Attendees whose Auth0 profile carries a Bluesky handle were locked out of the guest composer and the like button — the card told them to go post on Bluesky instead. That gate is gone: every signed-in attendee can post and like, subject only to the existing service-source gate (`interactive` — a thread from the discussion service plus a valid token). The public AppView stays read-only.

The idea behind the gate was still a good one, so it comes back as an invitation. A reader with a linked handle sees the existing thread callout — right above the composer — reworded:

> 🦋 You're on Bluesky as @handle — reply there if you like
> Your reply then appears under your own account instead of the shared bridge account.

It reuses the callout's existing `bskyUrl` link, adds no second link, and changes nothing about what the composer or the like button will do.

Testing: `npm run typecheck` — same 2 pre-existing errors (`Search.tsx:49`, `paperData.ts:75`), nothing new. No test runner in this repo; not exercised in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGxt1cxp9XVXWnfZZEKKen

---

**Merge order:** Merge after #2649 and #2650 — all three edit `src/components/BlueskyDiscussion.tsx` and conflict pairwise. Suggested order: #2649 → #2650 → #2651. This branch will need a rebase once the other two land.
