### PR TITLE
Fix missing space before the link on the error page

### DIFF
--- a/src/layouts/404Layout.astro
+++ b/src/layouts/404Layout.astro
@@ -19,8 +19,7 @@ const { frontmatter } = Astro.props;
       
       <h2>Trying to create a new page?</h2>
 
-      <p>If you are attempting to create a new webpage, please
-      <AnchorOpenGitHubToCreateNewPage client:only/>.</p>
+      <p>If you are attempting to create a new webpage, please <AnchorOpenGitHubToCreateNewPage client:only />.</p>
     </article>
   </div>
 </DefaultLayout>


### PR DESCRIPTION
## Summary

The 404 page was missing a space between "please" and the link text, rendering as:

> If you are attempting to create a new webpage, pleaseclick on this link.

instead of:

> If you are attempting to create a new webpage, please click on this link.

## Cause

In `src/layouts/404Layout.astro`, the paragraph text and the `<AnchorOpenGitHubToCreateNewPage client:only />` component were split across two lines:

```astro
<p>If you are attempting to create a new webpage, please
<AnchorOpenGitHubToCreateNewPage client:only/>.</p>
```

Astro's compiler trims the trailing whitespace/newline of a text node that sits directly before a component tag, so the space between "please" and the link was dropped entirely at compile time.

## Fix

Joined the text and the component onto a single line so a literal space character sits directly before the component tag and survives compilation:

```astro
<p>If you are attempting to create a new webpage, please <AnchorOpenGitHubToCreateNewPage client:only />.</p>
```

Before: "...new webpage, pleaseclick on this link."
After: "...new webpage, please click on this link."

I checked the rest of that block (and the paragraph above it) for the same class of problem; there were no other links, so no further changes were needed. This repo has no `prettier-plugin-astro`, so Prettier (run via the repo's own `--ignore-unknown` lint-staged config, and verified directly) does not format `.astro` files — the change matches the file's existing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRa9C9ff6KBFQABSQSPyg3