### PR TITLE
Let attendees remove their own comments in the discussion

### DIFF
--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -21,7 +21,10 @@
  * A reader can remove their own comments. That deletes the post from Bluesky as
  * well as taking it off this page and cannot be undone, so the control confirms
  * before it acts — and says that the conference keeps its own record either way,
- * since removing is not a way to take back something harmful.
+ * since removing is not a way to take back something harmful. Only comments
+ * written through this page can be removed here: a reply the reader wrote from
+ * their own Bluesky account lives in their repository, not in the shared one, so
+ * it is marked as theirs but is theirs to delete on Bluesky.
  *
  * A comment carries the attendee's real name unless they tick "Hide my name",
  * which swaps it for their stable pseudonym. Such a post is unnamed rather than
@@ -405,7 +408,10 @@ export default function BlueskyDiscussion({
   }, [likedUris]);
   const [refreshing, setRefreshing] = useState(false);
 
-  const { hasToken, getToken } = useGuestToken(Boolean(paperId));
+  // Also minted for an AppView-only thread: it buys no writes there, but it is
+  // what tells us the reader's own Bluesky handle, and so which replies in a
+  // read-only thread are theirs.
+  const { hasToken, getToken } = useGuestToken(Boolean(paperId || atUri));
 
   // Callers pass an inline array literal, so depend on its contents rather than
   // its identity — otherwise every render would build a new client and restart
@@ -905,18 +911,32 @@ export default function BlueskyDiscussion({
     onToggle: toggleLike,
   };
 
-  // The remove control, on the reader's own comments only. Without the guest UI
-  // there is nothing to act with, so no context is passed at all.
-  const ownContext: PostOwnContext | undefined = interactive
-    ? {
-        ownUris: new Set(
-          myComments
-            .filter((comment) => !comment.removed)
-            .map((comment) => comment.postUri),
-        ),
-        onRemove: (postUri) => void removeOwnComment(postUri),
-      }
-    : undefined;
+  // Which posts are marked "(me)": the guest comments they wrote through this
+  // page, and — when they have linked an account — the replies they wrote on
+  // Bluesky themselves. Only the first kind can be removed from here; the second
+  // is theirs to delete on Bluesky, where the post's own timestamp links.
+  //
+  // Marking does not need the service. A thread read straight from the AppView
+  // carries no guest attribution at all (every post comes back `guest: false`
+  // with no pseudonym), but it does carry author handles, so the reader's own
+  // Bluesky replies are still theirs to recognise. Removing does need it, hence
+  // `canRemove`.
+  const ownUris = new Set(
+    myComments
+      .filter((comment) => !comment.removed)
+      .map((comment) => comment.postUri),
+  );
+  const ownContext: PostOwnContext | undefined =
+    identity || ownUris.size > 0
+      ? {
+          ownUris,
+          handle: blueskyHandle
+            ? blueskyHandle.replace(/^@/, "").toLowerCase()
+            : null,
+          canRemove: interactive,
+          onRemove: (postUri) => void removeOwnComment(postUri),
+        }
+      : undefined;
 
   return (
     <section
@@ -939,7 +959,13 @@ export default function BlueskyDiscussion({
 
       {root && (
         <div style={announcementCardStyle}>
-          <PostCard bare like={likeContext} post={root} variant="root" />
+          <PostCard
+            bare
+            like={likeContext}
+            own={ownContext}
+            post={root}
+            variant="root"
+          />
 
           {root.bskyUrl && (
             <a

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -18,6 +18,11 @@
  * Commenting and liking appear only when the thread came from the service and
  * the reader's site session yields a token; everything else is read-only.
  *
+ * A reader can remove their own comments. That deletes the post from Bluesky as
+ * well as taking it off this page and cannot be undone, so the control confirms
+ * before it acts — and says that the conference keeps its own record either way,
+ * since removing is not a way to take back something harmful.
+ *
  * A comment carries the attendee's real name unless they tick "Hide my name",
  * which swaps it for their stable pseudonym. Such a post is unnamed rather than
  * untraceable — organizers can still tell who wrote it — so the label says what
@@ -28,7 +33,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, FormEvent } from "react";
 import PostCard from "./bluesky/PostCard";
-import type { PostLikeContext } from "./bluesky/PostCard";
+import type { PostLikeContext, PostOwnContext } from "./bluesky/PostCard";
 import ReplyList from "./bluesky/ReplyList";
 import SortToggle from "./bluesky/SortToggle";
 import { fetchAppViewThread } from "./bluesky/direct";
@@ -36,6 +41,8 @@ import { formatOpensAt, likeCountOf } from "./bluesky/format";
 import { createServiceClient } from "./bluesky/service";
 import type {
   MeResponse,
+  MyComment,
+  MyCommentsResponse,
   MyLikesResponse,
   ServiceClient,
 } from "./bluesky/service";
@@ -142,6 +149,24 @@ function collectUris(
     }
   }
   return into;
+}
+
+/**
+ * A reply list minus the given URIs and everything under them — the same reach
+ * removing a comment has, applied locally between the click and the poll that
+ * stops returning it.
+ */
+function dropUris(replies: ShapedPost[], uris: Set<string>): ShapedPost[] {
+  if (uris.size === 0) {
+    return replies;
+  }
+  return replies
+    .filter((reply) => !uris.has(reply.uri))
+    .map((reply) =>
+      reply.replies?.length
+        ? { ...reply, replies: dropUris(reply.replies, uris) }
+        : reply,
+    );
 }
 
 /** The server's merged like count for every post in a thread, keyed by URI. */
@@ -347,6 +372,15 @@ export default function BlueskyDiscussion({
   const [submitting, setSubmitting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingReplies, setPendingReplies] = useState<ShapedPost[]>([]);
+  // Which comments in this thread are the reader's own. The thread response is
+  // shared between readers and cannot say, so it comes from the per-user
+  // endpoint — and it is what puts the remove control on their posts only.
+  const [myComments, setMyComments] = useState<MyComment[]>([]);
+  // Comments removed in this session, applied over the thread until a poll stops
+  // returning them; put back if the removal turns out to have failed.
+  const [removedLocally, setRemovedLocally] = useState<Set<string>>(
+    () => new Set(),
+  );
   // Which posts *this reader* has liked, and — while an optimistic toggle is in
   // flight — a per-post adjustment laid over the server's total. The thread
   // response is shared between readers (nginx-cached) and so cannot carry either.
@@ -480,6 +514,44 @@ export default function BlueskyDiscussion({
     }
   }, [client, getToken, paperId]);
 
+  /**
+   * The reader's own comments in this thread, which is what marks their posts in
+   * the thread so the remove control can go on them.
+   *
+   * Unlike the likes this is not re-read on every poll: it only changes when the
+   * reader posts or removes something, and both do it themselves.
+   */
+  const syncMyComments = useCallback(async () => {
+    const token = paperId ? await getToken() : null;
+    if (!token || !paperId) {
+      return;
+    }
+
+    try {
+      const response = await client.fetchMyComments(paperId, token);
+      if (!response.ok) {
+        return;
+      }
+
+      const body = (await response.json()) as MyCommentsResponse;
+      if (Array.isArray(body.comments)) {
+        setMyComments(body.comments);
+      }
+    } catch {
+      // Without the list the reader just gets no remove control; the thread
+      // reads the same. Never surface this over the discussion itself.
+    }
+  }, [client, getToken, paperId]);
+
+  // Read once the guest UI is live. The list only changes when the reader posts
+  // or removes something, and both re-read it themselves, so it stays off the
+  // polling path.
+  useEffect(() => {
+    if (interactive) {
+      void syncMyComments();
+    }
+  }, [interactive, syncMyComments]);
+
   useEffect(() => {
     if (!data || data.thread.state !== "open") {
       return;
@@ -604,6 +676,7 @@ export default function BlueskyDiscussion({
         setDraft("");
 
         await refresh(true);
+        await syncMyComments();
       } catch (err) {
         setActionError(
           (err as Error).message || "Your comment could not be posted.",
@@ -621,6 +694,7 @@ export default function BlueskyDiscussion({
       paperId,
       refresh,
       submitting,
+      syncMyComments,
     ],
   );
 
@@ -696,6 +770,65 @@ export default function BlueskyDiscussion({
     [client, getToken, paperId, refresh],
   );
 
+  /**
+   * Remove one of the reader's own comments.
+   *
+   * The comment leaves the rendered thread straight away and comes back if the
+   * write fails. Nothing here can undo a removal that succeeded: the service
+   * deletes the post from Bluesky, and the confirmation in the control is the
+   * only step between the reader and that.
+   */
+  const removeOwnComment = useCallback(
+    async (postUri: string) => {
+      markInteraction();
+      setActionError(null);
+
+      const applyLocally = (removed: boolean) => {
+        setRemovedLocally((current) => {
+          const updated = new Set(current);
+          if (removed) {
+            updated.add(postUri);
+          } else {
+            updated.delete(postUri);
+          }
+          return updated;
+        });
+        setMyComments((current) =>
+          current.map((comment) =>
+            comment.postUri === postUri ? { ...comment, removed } : comment,
+          ),
+        );
+      };
+
+      applyLocally(true);
+
+      try {
+        const token = paperId ? await getToken() : null;
+        if (!token || !paperId) {
+          applyLocally(false);
+          setActionError(
+            "Your session expired. Reload the page and try again.",
+          );
+          return;
+        }
+
+        const response = await client.removeComment(paperId, token, postUri);
+        if (!response.ok) {
+          throw new Error(`The service returned ${response.status}.`);
+        }
+
+        await refresh(true);
+        await syncMyComments();
+      } catch (err) {
+        applyLocally(false);
+        setActionError(
+          (err as Error).message || "Your comment could not be removed.",
+        );
+      }
+    },
+    [client, getToken, markInteraction, paperId, refresh, syncMyComments],
+  );
+
   // ── render ──
 
   // Nothing is mapped for this paper (no session, withdrawn, or not in the
@@ -741,10 +874,15 @@ export default function BlueskyDiscussion({
     serverCounts,
   );
   // Pending (just-posted) replies stay pinned at the end regardless of sort so
-  // the author always sees their own comment.
+  // the author always sees their own comment. A comment the reader has just
+  // removed is dropped from both lists until the service stops returning it.
   const replies = [
-    ...sortReplies(root?.replies || [], sort, activeDeltas),
-    ...pendingReplies,
+    ...sortReplies(
+      dropUris(root?.replies || [], removedLocally),
+      sort,
+      activeDeltas,
+    ),
+    ...dropUris(pendingReplies, removedLocally),
   ];
   const remaining = COMMENT_LIMIT - graphemeLength(draft);
   // The two possible bylines the submit button can show — the real name and the
@@ -764,6 +902,19 @@ export default function BlueskyDiscussion({
     deltas: activeDeltas,
     onToggle: toggleLike,
   };
+
+  // The remove control, on the reader's own comments only. Without the guest UI
+  // there is nothing to act with, so no context is passed at all.
+  const ownContext: PostOwnContext | undefined = interactive
+    ? {
+        ownUris: new Set(
+          myComments
+            .filter((comment) => !comment.removed)
+            .map((comment) => comment.postUri),
+        ),
+        onRemove: (postUri) => void removeOwnComment(postUri),
+      }
+    : undefined;
 
   return (
     <section
@@ -799,12 +950,12 @@ export default function BlueskyDiscussion({
               {hasBlueskyAccount ? (
                 <span style={calloutNudgeStyle}>
                   <span>
-                    🦋 You're on Bluesky as @{blueskyHandle} — reply there if you
-                    like
+                    🦋 You're on Bluesky as @{blueskyHandle} — reply there if
+                    you like
                   </span>
                   <span style={calloutNudgeReasonStyle}>
-                    Your reply then appears under your own account instead of the
-                    shared bridge account.
+                    Your reply then appears under your own account instead of
+                    the shared bridge account.
                   </span>
                 </span>
               ) : (
@@ -1042,7 +1193,12 @@ export default function BlueskyDiscussion({
         </div>
       </div>
 
-      <ReplyList like={likeContext} maxDepth={maxDepth} replies={replies} />
+      <ReplyList
+        like={likeContext}
+        maxDepth={maxDepth}
+        own={ownContext}
+        replies={replies}
+      />
     </section>
   );
 }

--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -114,7 +114,7 @@ function truncateByline(name: string): string {
     : name;
 }
 
-/** Top-level ordering. "top" = most liked first (recency as tie-break);
+/** Top-level ordering. "top" = most liked first (oldest first as tie-break);
  *  "newest" = most recent first. Nested replies stay chronological.
  *
  *  The optimistic like `deltas` fold into the sort key as well as the count, so
@@ -130,8 +130,10 @@ function sortReplies(
     likeCountOf(post) + (deltas.get(post.uri) ?? 0);
   const byRecency = (a: ShapedPost, b: ShapedPost) =>
     (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+  const byAge = (a: ShapedPost, b: ShapedPost) =>
+    (a.createdAt ?? "").localeCompare(b.createdAt ?? "");
   const byLikes = (a: ShapedPost, b: ShapedPost) =>
-    likesOf(b) - likesOf(a) || byRecency(a, b);
+    likesOf(b) - likesOf(a) || byAge(a, b);
   return [...replies].sort(sort === "top" ? byLikes : byRecency);
 }
 

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -6,6 +6,11 @@
  * pseudonym must not lead to that profile. The timestamp links to the post
  * itself whenever it has a real URI, which a just-submitted comment does not
  * yet have.
+ *
+ * The reader's own posts are marked with a "(me)" beside the name, whether they
+ * came through the guest bridge or from the reader's own linked Bluesky account.
+ * It earns its place on an anonymous comment above all: that byline reads the
+ * same `p-4821` on every anonymous post in the thread.
  */
 
 import { useState } from "react";
@@ -40,14 +45,25 @@ export interface PostLikeContext {
 }
 
 /**
- * The remove control the reader gets on their OWN comments, lifted to the
- * discussion so every post reads one shared list of what is theirs.
+ * Which posts are the reader's, lifted to the discussion so every post reads one
+ * shared answer.
  *
- *  - `ownUris` — the reader's own comments still in the thread.
- *  - `onRemove` — take the given comment down for good.
+ *  - `ownUris` — their own guest comments still in the thread. Only these can be
+ *    removed: they live in the shared discuss account, which this service writes
+ *    for. A post in the reader's own repository is theirs to delete on Bluesky.
+ *  - `canRemove` — whether removing works at all here. A thread read straight
+ *    from the AppView is read-only, so posts are still marked as the reader's
+ *    but nothing is offered on them.
+ *  - `handle` — their linked Bluesky handle, lowercased and without the "@", or
+ *    null. Matching on the handle rather than the DID is what the site knows:
+ *    a handle the reader has since given up could in principle be held by
+ *    someone else, and the only consequence is one wrongly outlined post.
+ *  - `onRemove` — take the given guest comment down for good.
  */
 export interface PostOwnContext {
   ownUris: Set<string>;
+  handle: string | null;
+  canRemove: boolean;
   onRemove: (postUri: string) => void;
 }
 
@@ -76,6 +92,14 @@ const likeChipStyle: CSSProperties = {
   borderRadius: "0.5rem",
   border: "1px solid #e5e7eb",
   fontSize: "0.82rem",
+};
+
+/** "(me)", beside the name on the reader's own posts, in the heading orange. */
+const ownMarkerStyle: CSSProperties = {
+  marginLeft: "0.35rem",
+  color: "var(--color-primary, #df6824)",
+  fontWeight: 600,
+  fontSize: "0.85rem",
 };
 
 /** The chip shape again, as a plain button: the remove controls wear it. */
@@ -184,7 +208,7 @@ function RemoveControl({
 }) {
   const [confirming, setConfirming] = useState(false);
 
-  if (!own?.ownUris.has(post.uri)) {
+  if (!own?.canRemove || !own.ownUris.has(post.uri)) {
     return null;
   }
 
@@ -243,6 +267,11 @@ export default function PostCard({
   bare = false,
 }: PostCardProps) {
   const isRoot = variant === "root";
+  const isOwn =
+    own !== undefined &&
+    (own.ownUris.has(post.uri) ||
+      (own.handle !== null &&
+        (post.author?.handle ?? "").toLowerCase() === own.handle));
   const { name, body } = displayPost(post);
   const profile = post.guest ? null : profileUrl(post.author);
   // Guest comments are real posts in the shared bridge repo, so their bsky.app
@@ -278,6 +307,7 @@ export default function PostCard({
           ) : (
             <span style={{ fontWeight: 600 }}>{name}</span>
           )}
+          {isOwn && <span style={ownMarkerStyle}>(me)</span>}
           <div style={{ fontSize: "0.85rem", color: "#6b7280" }}>
             {post.guest
               ? "VIS attendee"

--- a/src/components/bluesky/PostCard.tsx
+++ b/src/components/bluesky/PostCard.tsx
@@ -8,6 +8,7 @@
  * yet have.
  */
 
+import { useState } from "react";
 import type { CSSProperties } from "react";
 import Avatar from "./Avatar";
 import { EmbedCard, EmbedImages } from "./Embeds";
@@ -38,11 +39,25 @@ export interface PostLikeContext {
   onToggle: (postUri: string) => void;
 }
 
+/**
+ * The remove control the reader gets on their OWN comments, lifted to the
+ * discussion so every post reads one shared list of what is theirs.
+ *
+ *  - `ownUris` — the reader's own comments still in the thread.
+ *  - `onRemove` — take the given comment down for good.
+ */
+export interface PostOwnContext {
+  ownUris: Set<string>;
+  onRemove: (postUri: string) => void;
+}
+
 interface PostCardProps {
   post: ShapedPost;
   /** "root" is the post a thread hangs off; "reply" is everything below it. */
   variant?: "root" | "reply";
   like?: PostLikeContext;
+  /** Shared own-comment state; absent where the reader may not write. */
+  own?: PostOwnContext;
   /**
    * Drop the card's own border, corners and background so it can sit inside
    * another bordered container (e.g. the announcement + Bluesky-callout box).
@@ -61,6 +76,15 @@ const likeChipStyle: CSSProperties = {
   borderRadius: "0.5rem",
   border: "1px solid #e5e7eb",
   fontSize: "0.82rem",
+};
+
+/** The chip shape again, as a plain button: the remove controls wear it. */
+const plainChipStyle: CSSProperties = {
+  ...likeChipStyle,
+  backgroundColor: "#fff",
+  color: "inherit",
+  cursor: "pointer",
+  fontFamily: "inherit",
 };
 
 /**
@@ -143,10 +167,79 @@ function LikeControl({
   );
 }
 
+/**
+ * "Remove", on the reader's own comments only.
+ *
+ * Removing deletes the post from Bluesky as well as taking it off this page,
+ * and nothing can put it back, so the button asks once before it acts. The
+ * confirmation also says what removal does not do: the conference keeps its own
+ * record of the comment.
+ */
+function RemoveControl({
+  post,
+  own,
+}: {
+  post: ShapedPost;
+  own?: PostOwnContext;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (!own?.ownUris.has(post.uri)) {
+    return null;
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        onClick={() => setConfirming(true)}
+        style={plainChipStyle}
+        title="Remove this comment"
+        type="button"
+      >
+        Remove
+      </button>
+    );
+  }
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+        gap: "0.4rem 0.5rem",
+      }}
+    >
+      <span>
+        This deletes the comment from Bluesky as well and cannot be undone.
+        Conference organizers keep a copy.
+      </span>
+      <button
+        onClick={() => {
+          setConfirming(false);
+          own.onRemove(post.uri);
+        }}
+        style={{ ...plainChipStyle, borderColor: "#b91c1c", color: "#b91c1c" }}
+        type="button"
+      >
+        Remove
+      </button>
+      <button
+        onClick={() => setConfirming(false)}
+        style={plainChipStyle}
+        type="button"
+      >
+        Cancel
+      </button>
+    </span>
+  );
+}
+
 export default function PostCard({
   post,
   variant = "reply",
   like,
+  own,
   bare = false,
 }: PostCardProps) {
   const isRoot = variant === "root";
@@ -229,6 +322,7 @@ export default function PostCard({
         }}
       >
         <LikeControl isRoot={isRoot} like={like} post={post} />
+        {!isRoot && <RemoveControl own={own} post={post} />}
         {!isRoot && reposts > 0 && (
           <span>
             {reposts} {reposts === 1 ? "repost" : "reposts"}

--- a/src/components/bluesky/ReplyList.tsx
+++ b/src/components/bluesky/ReplyList.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef } from "react";
-import type { PostLikeContext } from "./PostCard";
+import type { PostLikeContext, PostOwnContext } from "./PostCard";
 import ReplyThread from "./ReplyThread";
 import type { ShapedPost } from "./types";
 
@@ -25,6 +25,7 @@ interface ReplyListProps {
   replies: ShapedPost[];
   maxDepth: number;
   like?: PostLikeContext;
+  own?: PostOwnContext;
 }
 
 interface Point {
@@ -40,7 +41,12 @@ function prefersReducedMotion(): boolean {
   );
 }
 
-export default function ReplyList({ replies, maxDepth, like }: ReplyListProps) {
+export default function ReplyList({
+  replies,
+  maxDepth,
+  like,
+  own,
+}: ReplyListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const nodes = useRef<Map<string, HTMLDivElement>>(new Map());
   const previous = useRef<Map<string, Point>>(new Map());
@@ -173,6 +179,7 @@ export default function ReplyList({ replies, maxDepth, like }: ReplyListProps) {
               depth={0}
               like={like}
               maxDepth={maxDepth}
+              own={own}
               post={reply}
             />
           </div>

--- a/src/components/bluesky/ReplyThread.tsx
+++ b/src/components/bluesky/ReplyThread.tsx
@@ -5,7 +5,7 @@
  */
 
 import PostCard from "./PostCard";
-import type { PostLikeContext } from "./PostCard";
+import type { PostLikeContext, PostOwnContext } from "./PostCard";
 import type { ShapedPost } from "./types";
 
 interface ReplyThreadProps {
@@ -14,6 +14,8 @@ interface ReplyThreadProps {
   maxDepth: number;
   /** Shared like state, threaded down so every reply gets its own control. */
   like?: PostLikeContext;
+  /** Shared own-comment state, threaded down the same way. */
+  own?: PostOwnContext;
 }
 
 export default function ReplyThread({
@@ -21,6 +23,7 @@ export default function ReplyThread({
   depth,
   maxDepth,
   like,
+  own,
 }: ReplyThreadProps) {
   const replies = post.replies || [];
 
@@ -33,7 +36,7 @@ export default function ReplyThread({
         paddingLeft: depth > 0 ? "0.75rem" : 0,
       }}
     >
-      <PostCard like={like} post={post} />
+      <PostCard like={like} own={own} post={post} />
 
       {depth < maxDepth &&
         replies.map((reply, index) => (
@@ -42,6 +45,7 @@ export default function ReplyThread({
             key={reply.uri || `${depth}-${index}`}
             like={like}
             maxDepth={maxDepth}
+            own={own}
             post={reply}
           />
         ))}

--- a/src/components/bluesky/format.ts
+++ b/src/components/bluesky/format.ts
@@ -74,17 +74,23 @@ export function postUrl(uri?: string): string | null {
 
 /**
  * Who to credit. Guest replies all live in one Bluesky account, so their
- * attribution is baked into the post text as "💬 Ada Lovelace: …" — that is what
+ * attribution is baked into the post text as "Ada Lovelace: …" — that is what
  * readers on Bluesky itself see — and is stripped here so it is not shown twice.
  * Replies whose author hid their name also carry `pseudonym`, which the service
  * reads from our authorship log rather than by parsing text; prefer it when it
  * is there.
+ *
+ * The leading 💬 is optional: the service has written the label without it since
+ * the first release, and requiring the emoji left every named comment credited
+ * to "VIS attendee" with its byline still sitting in the body. Only guest posts
+ * are parsed this way, and every one of them carries a label, so there is no
+ * ordinary comment for the pattern to bite.
  */
 export function displayPost(post: ShapedPost): { name: string; body: string } {
   const text = post.text || "";
 
   if (post.guest) {
-    const match = /^💬\s*([^:]{1,80}):\s*/.exec(text);
+    const match = /^(?:💬\s*)?([^:\n]{1,80}):\s*/.exec(text);
     return {
       name: post.pseudonym || match?.[1]?.trim() || "VIS attendee",
       body: match ? text.slice(match[0].length) : text,

--- a/src/components/bluesky/service.ts
+++ b/src/components/bluesky/service.ts
@@ -21,6 +21,27 @@ export interface MyLikesResponse {
 }
 
 /**
+ * One comment of the caller's own, from
+ * GET /api/threads/{paperId}/my-comments. The thread response is shared between
+ * readers and so cannot say which posts belong to whom; this is what lets the
+ * page offer the remove control on the reader's own comments and nobody else's.
+ *
+ * `text` is what they typed, without the display-name prefix the posted version
+ * carries. `removed` is true for a comment they have already taken down — its
+ * post is gone from Bluesky, so it is not in the thread response at all.
+ */
+export interface MyComment {
+  postUri: string;
+  text: string;
+  createdAt: string | null;
+  removed: boolean;
+}
+
+export interface MyCommentsResponse {
+  comments: MyComment[];
+}
+
+/**
  * GET /api/me — who the bearer token belongs to. `name` is the attendee's real
  * name from their conference login and is null when the service has none;
  * `pseudonym` is their stable stand-in and is always present. `bluesky` is the
@@ -52,6 +73,12 @@ export interface ServiceClient {
     token: string,
     postUri: string,
     liked: boolean,
+  ): Promise<Response>;
+  fetchMyComments(paperId: string, token: string): Promise<Response>;
+  removeComment(
+    paperId: string,
+    token: string,
+    postUri: string,
   ): Promise<Response>;
 }
 
@@ -136,6 +163,30 @@ export function createServiceClient(bases: string[]): ServiceClient {
           "content-type": "application/json",
         },
         body: JSON.stringify({ text, anonymous }),
+      });
+    },
+
+    fetchMyComments(paperId, token) {
+      return request(threadPath(paperId, "/my-comments"), {
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+        },
+      });
+    },
+
+    // Takes one of the caller's OWN comments down. The service deletes the post
+    // from Bluesky, so the comment goes from the paper page and from Bluesky at
+    // once, and there is no way back. What it does not delete is the service's
+    // own record of the comment, which organizers keep.
+    removeComment(paperId, token, postUri) {
+      return request(threadPath(paperId, "/comments"), {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ postUri }),
       });
     },
 


### PR DESCRIPTION
Someone who posts a comment on a paper page cannot take it back.

Each of the reader's own comments now carries a **Remove** button. It asks once first: "This deletes the comment from Bluesky as well and cannot be undone. Conference organizers keep a copy." Both halves matter — the post really is deleted from Bluesky, and the conference keeps its own record, so removing is not a way to take back something harmful.

The reader's own posts are marked with a **(you)** beside the name, in the orange headings use: their guest comments, and — when they have linked an account — the replies they wrote on Bluesky themselves, matched on the handle from `/api/me`. It matters most on anonymous comments, where every byline in the thread reads the same `p-4821`.

Removing stays limited to guest comments. A reply in the reader's own repository is theirs to delete on Bluesky, which the post's timestamp already links to. Marking works in an AppView-only thread as well, where nothing can be removed; guest comments are unmarked there, since the AppView reports every post as `guest: false` with no pseudonym.

Which guest comments belong to the reader comes from `GET /api/threads/{paperId}/my-comments`; the thread response is shared between readers and cannot say.

Two fixes ride along:

- The byline parser required a leading 💬 the service has never sent, so every named guest comment was credited to "VIS attendee" with its byline left in the body.
- "Most liked" now breaks ties by oldest reply first, not newest.

Needs ieee-vgtc/conferentech#9, which is deployed.

Not yet clicked through in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi5mR7Vx6NNWXe3CDYRKoy
