### PR TITLE
Show the Bluesky discussion for panels and invited talks

### DIFF
--- a/src/components/BlueskyDiscussion.tsx
+++ b/src/components/BlueskyDiscussion.tsx
@@ -720,8 +720,8 @@ export default function BlueskyDiscussion({
         <h2 style={{ marginBottom: "0.5rem" }}>Discussion</h2>
         <p style={{ color: "#6b7280", margin: 0 }}>
           {opensAt
-            ? `The discussion for this paper opens shortly before its session, on ${opensAt}.`
-            : "The discussion for this paper opens shortly before its session."}
+            ? `The discussion opens shortly before the session, on ${opensAt}.`
+            : "The discussion opens shortly before the session."}
         </p>
       </section>
     );
@@ -799,12 +799,12 @@ export default function BlueskyDiscussion({
               {hasBlueskyAccount ? (
                 <span style={calloutNudgeStyle}>
                   <span>
-                    🦋 You're on Bluesky as @{blueskyHandle} — reply there if you
-                    like
+                    🦋 You're on Bluesky as @{blueskyHandle} — reply there if
+                    you like
                   </span>
                   <span style={calloutNudgeReasonStyle}>
-                    Your reply then appears under your own account instead of the
-                    shared bridge account.
+                    Your reply then appears under your own account instead of
+                    the shared bridge account.
                   </span>
                 </span>
               ) : (

--- a/src/pages/program/session/[sessionId].astro
+++ b/src/pages/program/session/[sessionId].astro
@@ -1,6 +1,8 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
+import BlueskyDiscussion from "../../../components/BlueskyDiscussion";
 import { fetchAllSessions } from "../../../utils/paperData";
+import { hasOwnDiscussion } from "../../../utils/discussionSlots";
 import type {
   ProgramSession,
   ProgramSessionList,
@@ -154,6 +156,14 @@ const frontmatter = {
                 {slot.contributors.join(", ")}
               </p>
             )}
+            {/* Panels and invited talks have no paper page, so their Bluesky
+                discussion — the thread of replies to the announcement post,
+                proxied through bsky.tech.ieeevis.org — belongs here. */}
+            {hasOwnDiscussion(slot) && (
+              <div class="program-presentation-discussion not-prose">
+                <BlueskyDiscussion client:visible paperId={slot.slot_id} />
+              </div>
+            )}
           </article>
         ))
       }
@@ -219,6 +229,10 @@ const frontmatter = {
       margin: 0;
       color: var(--color-gray-700);
       font-size: 0.9rem;
+    }
+
+    .program-presentation-discussion {
+      margin-top: 0.6rem;
     }
   </style>
 </PageLayout>

--- a/src/utils/discussionSlots.ts
+++ b/src/utils/discussionSlots.ts
@@ -1,0 +1,26 @@
+import type { ProgramTimeSlot } from "../types/program";
+
+/** Slot_id words that mark an invited talk — the keynote, the capstone, a
+ *  VISions talk. Mirrors INVITED_TALKS in conferentech's announce bot. */
+const INVITED_TALK_WORDS = ["keynote", "capstone", "visions"];
+
+/**
+ * Whether this slot's Bluesky discussion belongs on the session page.
+ *
+ * A paper talk has a paper page, and that is where its discussion lives. The
+ * slots left over are the ones the announce bot posts about but the site builds
+ * no page for: panels and invited talks.
+ *
+ * Deciding it here rather than asking the service about every slot keeps the
+ * opening remarks, the awards and the breaks from polling an endpoint that will
+ * only ever answer "unknown" for them. A slot that slips through anyway costs
+ * nothing: the embed renders nothing for an id the service does not know.
+ */
+export function hasOwnDiscussion(slot: ProgramTimeSlot): boolean {
+  if (slot.uid) return false; // its discussion is on the paper page
+  const slotId = slot.slot_id?.toLowerCase() ?? "";
+  return (
+    slot.paper_type?.toLowerCase() === "panel" ||
+    INVITED_TALK_WORDS.some((word) => slotId.includes(word))
+  );
+}


### PR DESCRIPTION
The discussion embed only ever appeared on paper pages. Panels, the opening keynote, the capstone and the VISions talks are slots with no paper UUID, so they have no paper page — their Bluesky threads exist but nothing on the site points at them. (The announce bot side is ieee-vgtc/conferentech#8.)

The session page now renders the embed under each such slot, keyed by `slot_id` — the service resolves either a slot_id or a paper UUID.

Which slots get one is decided in `src/utils/discussionSlots.ts`: no paper UUID, and either `paper_type === "Panel"` or a slot_id containing "keynote", "capstone" or "visions". That mirrors what the bot announces. Deciding it here rather than asking the service about every slot keeps the opening remarks, the awards slots and the breaks from polling an endpoint that will only ever answer "unknown" for them.

Built against the 2025 program (`weekOfVis` flipped on locally), the pages that render a discussion are exactly:

- the 8 panel sessions → `v-panels-panel1` … `v-panels-panel8`
- `conf-opening1` → `opening-keynote` (the "Opening" slot in the same session gets none)
- `conf-closing` → `closing-capstone` (the "Closing" slot gets none)

No paper session, workshop, tutorial or awards slot renders one.

Also: the "not open yet" line said "The discussion for this paper opens shortly before its session" — now "The discussion opens shortly before the session", since it shows under panels and talks too.

The pre-commit hook reformatted two unrelated lines in `BlueskyDiscussion.tsx` (pre-existing Prettier drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S3Fx4DWoQisawRpFgRitQ
